### PR TITLE
Goledzki scala upgrade client to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.version.major>2.11</scala.version.major>
     <scala.version>${scala.version.major}.8</scala.version>
-    <akka.version>2.4.8</akka.version>
+    <akka.version>2.4.20</akka.version>
     <aws.sdk.version>1.10.3</aws.sdk.version>
   </properties>
 
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.github.gilbertw1</groupId>
       <artifactId>slack-scala-client_2.11</artifactId>
-      <version>0.1.8</version>
+      <version>0.2.2</version>
     </dependency>
 
     <dependency>
@@ -99,6 +99,12 @@
       <artifactId>mockito-core</artifactId>
       <version>2.0.31-beta</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.joda</groupId>
+      <artifactId>joda-convert</artifactId>
+      <version>1.9.2</version>
     </dependency>
 
   </dependencies>

--- a/src/main/scala/com/sumologic/sumobot/plugins/advice/Advice.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/advice/Advice.scala
@@ -22,17 +22,15 @@ import com.sumologic.sumobot.core.model.{IncomingMessage, OutgoingMessage}
 import com.sumologic.sumobot.plugins.BotPlugin
 import org.apache.http.HttpResponse
 import org.apache.http.util.EntityUtils
-import play.libs.Json
-
-import scala.collection.JavaConverters._
+import play.api.libs.json.Json
 
 object Advice {
   val AdviceAbout = BotPlugin.matchText("(what should I do about|what do you think about|how do you handle) (.*)")
   val RandomAdvice = BotPlugin.matchText("I need some advice")
 
   private[advice] def parseResponse(response: HttpResponse): Seq[String] = {
-    val json = Json.parse(EntityUtils.toString(response.getEntity))
-    json.findValues("advice").asScala.map(_.asText())
+    val json = Json.toJson(EntityUtils.toString(response.getEntity))
+    (json \\ "advice").map(_.as[String])
   }
 }
 

--- a/src/main/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorris.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorris.scala
@@ -24,7 +24,7 @@ import com.sumologic.sumobot.core.model.{IncomingMessage, OutgoingMessage}
 import com.sumologic.sumobot.plugins.BotPlugin
 import org.apache.http.HttpResponse
 import org.apache.http.util.EntityUtils
-import play.libs.Json
+import play.api.libs.json.Json
 import slack.models.User
 
 class ChuckNorris extends BotPlugin {
@@ -58,8 +58,8 @@ class ChuckNorris extends BotPlugin {
   private def convertResponse(message: IncomingMessage, response: HttpResponse): OutgoingMessage = {
     if (response.getStatusLine.getStatusCode == 200) {
       val json = Json.parse(EntityUtils.toString(response.getEntity))
-      val joke = json.at("/value/joke")
-      val cleanJoke = joke.asText().
+      val joke = json \ "value" \ "joke"
+      val cleanJoke = joke.as[String].
         replaceAllLiterally("&quot;", "\"")
       message.message(cleanJoke)
     } else {

--- a/src/test/scala/com/sumologic/sumobot/core/ReceptionistTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/core/ReceptionistTest.scala
@@ -21,14 +21,14 @@ package com.sumologic.sumobot.core
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
 import com.sumologic.sumobot.brain.InMemoryBrain
-import com.sumologic.sumobot.core.Receptionist.{RtmStateResponse, RtmStateRequest}
-import com.sumologic.sumobot.core.model.{OpenIM, IncomingMessage}
+import com.sumologic.sumobot.core.Receptionist.{RtmStateRequest, RtmStateResponse}
+import com.sumologic.sumobot.core.model.{IncomingMessage, OpenIM}
 import com.sumologic.sumobot.plugins.BotPlugin.{InitializePlugin, PluginAdded}
 import com.sumologic.sumobot.test.SumoBotSpec
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-import slack.api.{BlockingSlackApiClient, RtmStartState}
+import slack.api.{BlockingSlackApiClient, RtmStartState, SlackApiClient}
 import slack.models._
 import slack.rtm.{RtmState, SlackRtmClient}
 
@@ -49,34 +49,34 @@ class ReceptionistTest
   private val startState = new RtmStartState("http://nothing/", self, team, users = List(self, somebodyElse), channels = List(channel), List.empty, ims = List(im), List.empty)
 
   val state = new RtmState(startState)
-  val client = mock[SlackRtmClient]
-  val blockingClient = mock[BlockingSlackApiClient]
-  when(client.state).thenReturn(state)
-  when(client.apiClient).thenReturn(blockingClient)
+  val rtmClient = mock[SlackRtmClient]
+  val syncClient = mock[BlockingSlackApiClient]
+  val asyncClient = mock[SlackApiClient]
+  when(rtmClient.state).thenReturn(state)
 
   private val probe = new TestProbe(system)
   system.eventStream.subscribe(probe.ref, classOf[IncomingMessage])
   private val brain = system.actorOf(Props(classOf[InMemoryBrain]), "brain")
-  private val sut = system.actorOf(Props(classOf[Receptionist], client, brain))
+  private val sut = system.actorOf(Props(classOf[Receptionist], rtmClient, syncClient, asyncClient, brain))
 
   "Receptionist" should {
     "mark messages as addressed to us" when {
       "message starts with @mention" in {
-        sut ! new Message(currentTimeStamp, channel.id, somebodyElse.id, s"<@${self.id}> hello dude1", None)
+        sut ! new Message(currentTimeStamp, channel.id, somebodyElse.id, s"<@${self.id}> hello dude1", None, None)
         val result = probe.expectMsgClass(classOf[IncomingMessage])
         result.canonicalText should be("hello dude1")
         result.addressedToUs should be(true)
       }
 
       "message starts with our name" in {
-        sut ! new Message(currentTimeStamp, channel.id, somebodyElse.id, s"${self.name} hello dude2", None)
+        sut ! new Message(currentTimeStamp, channel.id, somebodyElse.id, s"${self.name} hello dude2", None, None)
         val result = probe.expectMsgClass(classOf[IncomingMessage])
         result.canonicalText should be("hello dude2")
         result.addressedToUs should be(true)
       }
 
       "message is an instant message" in {
-        sut ! new Message(currentTimeStamp, im.id, somebodyElse.id, "hello dude3", None)
+        sut ! new Message(currentTimeStamp, im.id, somebodyElse.id, "hello dude3", None, None)
         val result = probe.expectMsgClass(classOf[IncomingMessage])
         result.canonicalText should be("hello dude3")
         result.addressedToUs should be(true)
@@ -84,7 +84,7 @@ class ReceptionistTest
     }
 
     "mark message as not addressed to us otherwise" in {
-      sut ! new Message(currentTimeStamp, channel.id, somebodyElse.id, "just a message", None)
+      sut ! new Message(currentTimeStamp, channel.id, somebodyElse.id, "just a message", None, None)
       val result = probe.expectMsgClass(classOf[IncomingMessage])
       result.canonicalText should be("just a message")
       result.addressedToUs should be(false)
@@ -102,7 +102,7 @@ class ReceptionistTest
     }
 
     "route message when timestamp cannot be parsed" in {
-      sut ! new Message("humbug", channel.id, somebodyElse.id, "just a message", None)
+      sut ! new Message("humbug", channel.id, somebodyElse.id, "just a message", None, None)
       val result = probe.expectMsgClass(classOf[IncomingMessage])
       result.canonicalText should be("just a message")
       result.addressedToUs should be(false)
@@ -113,12 +113,12 @@ class ReceptionistTest
       "the time stamp is older than 60 seconds" in {
         val now = System.currentTimeMillis()
         val tooLongAgo = (now - (1000 * 61))/1000
-        sut ! new Message(s"$tooLongAgo.000005", im.id, somebodyElse.id, "just a message", None)
+        sut ! new Message(s"$tooLongAgo.000005", im.id, somebodyElse.id, "just a message", None, None)
         probe.expectNoMsg(1.second)
       }
 
       "it originated from our user" in {
-        sut ! new Message(currentTimeStamp, channel.id, self.id, s"This is me!", None)
+        sut ! new Message(currentTimeStamp, channel.id, self.id, s"This is me!", None, None)
         probe.expectNoMsg(1.second)
       }
     }
@@ -131,16 +131,14 @@ class ReceptionistTest
       initMessage.pluginRegistry should not be (null)
     }
 
-    // TODO: Fix this test and reenable.
-    "open a new IM channel asynchronously when asked" ignore {
+    "open a new IM channel asynchronously when asked" in {
       case object DoneWithThat
       sut ! OpenIM(somebodyElse.id, probe.ref, DoneWithThat)
       sut ! ImOpened(somebodyElse.id, im.id)
       probe.expectMsgClass(DoneWithThat.getClass)
     }
 
-    // TODO: Fix this test and reenable.
-    "return the RTM state when asked" ignore {
+    "return the RTM state when asked" in {
       sut ! RtmStateRequest(probe.ref)
       probe.expectMsgClass(classOf[RtmStateResponse])
     }

--- a/src/test/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorrisTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorrisTest.scala
@@ -19,17 +19,16 @@
 package com.sumologic.sumobot.plugins.chuck
 
 import com.sumologic.sumobot.test.SumoBotSpec
-import play.libs.Json
+import play.api.libs.json.Json
 
 class ChuckNorrisTest extends SumoBotSpec {
   val jsonText = "{ \"type\": \"success\", \"value\": { \"id\": 518, \"joke\": \"Chuck Norris doesn't cheat death. He wins fair and square.\", \"categories\": [] } }"
 
   "ChuckNorris" should {
-    // TODO: Fix this test and reenable.
-    "parse JSON" ignore {
+    "parse JSON" in {
       val json = Json.parse(jsonText)
-      val joke = json.at("/value/joke")
-      joke.asText() should be ("Chuck Norris doesn't cheat death. He wins fair and square.")
+      val joke = json \ "value" \ "joke"
+      joke.as[String] should be ("Chuck Norris doesn't cheat death. He wins fair and square.")
     }
   }
 }


### PR DESCRIPTION
Upgrading `scala-slack-client` library to 2.2 due to the following error: https://github.com/gilbertw1/slack-scala-client/issues/43
= e.g.
```
[sumobot-akka.actor.default-dispatcher-11] [akka://sumobot/user/$a] [SlackRtmClient] Error reading event: {"type":"desktop_notification"
[...]
play.api.libs.json.JsResultException: JsResultException(errors:List((,List(ValidationError(List(Invalid type property: {}),WrappedArray(desktop_notification))))))
```

Confirmed the Sumobot works after the upgrade by manually running it with simple included plugins like help, Chuck Norris or braindump