### PR TITLE
Accepting bot messages with attachments, sending images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.version.major>2.11</scala.version.major>
-    <scala.version>${scala.version.major}.8</scala.version>
+    <scala.version>${scala.version.major}.12</scala.version>
     <akka.version>2.4.20</akka.version>
     <aws.sdk.version>1.10.3</aws.sdk.version>
   </properties>
@@ -92,6 +92,17 @@
           <artifactId>specs2_${scala.version.major}</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.typesafe.play</groupId>
+      <artifactId>play-json_2.11</artifactId>
+      <version>2.6.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-http_2.11</artifactId>
+      <version>10.0.10</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.github.gilbertw1</groupId>
       <artifactId>slack-scala-client_2.11</artifactId>
-      <version>0.2.2</version>
+      <version>0.2.3</version>
     </dependency>
 
     <dependency>

--- a/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
@@ -91,7 +91,7 @@ class Receptionist(rtmClient: SlackRtmClient,
       rtmClient.sendMessage(channel.id, text)
 
     case OutgoingImage(channel, imageFile, contentType, title) =>
-      log.info(s"Sending - ${channel.name} image worth of ${imageFile.length()} characters")
+      log.info(s"Sending image (${imageFile.length()} bytes) to ${channel.name}")
       val fut = asyncClient.uploadFile(content = Left(imageFile), filetype = Some(contentType), title = Some(title),
         filename = Some(imageFile.getName), channels = Some(Seq(channel.name)))
       fut.onComplete {

--- a/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
@@ -18,12 +18,14 @@
  */
 package com.sumologic.sumobot.core
 
+import java.io.File
+
 import akka.actor._
 import com.sumologic.sumobot.core.Receptionist.{RtmStateRequest, RtmStateResponse}
-import com.sumologic.sumobot.core.model._
+import com.sumologic.sumobot.core.model.{IncomingMessageAttachment, _}
 import com.sumologic.sumobot.plugins.BotPlugin.{InitializePlugin, PluginAdded, PluginRemoved}
 import slack.api.{BlockingSlackApiClient, SlackApiClient}
-import slack.models.{ImOpened, Message, MessageChanged}
+import slack.models.{ActionField, Attachment, BotMessage, ImOpened, Message, MessageChanged, User}
 import slack.rtm.{RtmState, SlackRtmClient}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -96,7 +98,7 @@ class Receptionist(rtmClient: SlackRtmClient,
 
     case OpenIM(userId, doneRecipient, doneMessage) =>
       asyncClient.openIm(userId)
-      pendingIMSessionsByUserId = pendingIMSessionsByUserId + (userId ->(doneRecipient, doneMessage))
+      pendingIMSessionsByUserId = pendingIMSessionsByUserId + (userId -> (doneRecipient, doneMessage))
 
     case message: Message if !tooOld(message.ts, message) =>
       translateAndDispatch(message.channel, message.user, message.text)
@@ -105,30 +107,37 @@ class Receptionist(rtmClient: SlackRtmClient,
       val message = messageChanged.message
       translateAndDispatch(messageChanged.channel, message.user, message.text)
 
+    case botMessage: BotMessage if !tooOld(botMessage.ts, botMessage) && botMessage.username.isDefined =>
+        translateAndDispatch(botMessage.channel, botMessage.username.get, botMessage.text, fromBot = true, botMessage.attachments)
+
     case RtmStateRequest(sendTo) =>
       sendTo ! RtmStateResponse(rtmClient.state)
   }
 
-  protected def translateMessage(channelId: String, userId: String, text: String): IncomingMessage = {
-
+  protected def translateMessage(channelId: String, from: Sender, text: String, attachments: Seq[IncomingMessageAttachment]): IncomingMessage = {
     val channel = Channel.forChannelId(rtmClient.state, channelId)
-    val sentByUser = rtmClient.state.users.find(_.id == userId).
-      getOrElse(throw new IllegalStateException(s"Message from unknown user: $userId"))
 
     text match {
       case atMention(user, text) if user == selfId =>
-        IncomingMessage(text.trim, true, channel, sentByUser)
+        IncomingMessage(text.trim, true, channel, from, attachments)
       case atMentionWithoutColon(user, text) if user == selfId =>
-        IncomingMessage(text.trim, true, channel, sentByUser)
+        IncomingMessage(text.trim, true, channel, from, attachments)
       case simpleNamePrefix(name, text) if name.equalsIgnoreCase(selfName) =>
-        IncomingMessage(text.trim, true, channel, sentByUser)
+        IncomingMessage(text.trim, true, channel, from, attachments)
       case _ =>
-        IncomingMessage(text.trim, channel.isInstanceOf[InstantMessageChannel], channel, sentByUser)
+        IncomingMessage(text.trim, channel.isInstanceOf[InstantMessageChannel], channel, from, attachments)
     }
   }
 
-  private def translateAndDispatch(channelId: String, userId: String, text: String): Unit = {
-    val msgToBot = translateMessage(channelId, userId, text)
+  private def translateAndDispatch(channelId: String, userId: String, text: String, fromBot: Boolean = false, attachments: Seq[Attachment] = Seq()): Unit = {
+    val sentBy: Sender = if (!fromBot) {
+      val slackUser: slack.models.User = rtmClient.state.users.find(_.id == userId).
+        getOrElse(throw new IllegalStateException(s"Message from unknown user: $userId"))
+      UserSender(slackUser)
+    } else {
+      BotSender(userId)
+    }
+    val msgToBot = translateMessage(channelId, sentBy, text, attachments.map(a => IncomingMessageAttachment(a.text.getOrElse(""))))
     if (userId != selfId) {
       log.info(s"Dispatching message: $msgToBot")
       context.system.eventStream.publish(msgToBot)

--- a/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
@@ -18,6 +18,8 @@
  */
 package com.sumologic.sumobot.core.model
 
+import java.io.File
+
 import akka.actor.ActorRef
 import slack.models.User
 
@@ -31,6 +33,9 @@ case class IncomingMessage(canonicalText: String,
                            sentBy: Sender,
                            attachments: Seq[IncomingMessageAttachment] = Seq())
 case class IncomingMessageAttachment(text: String)
+
+case class OutgoingImage(channel: Channel, image: File, contentType: String, title: String)
+
 
 sealed abstract class Sender {
   def slackReference: String

--- a/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
@@ -28,4 +28,21 @@ case class OpenIM(userId: String, doneRecipient: ActorRef, doneMessage: AnyRef)
 case class IncomingMessage(canonicalText: String,
                            addressedToUs: Boolean,
                            channel: Channel,
-                           sentByUser: User)
+                           sentBy: Sender,
+                           attachments: Seq[IncomingMessageAttachment] = Seq())
+case class IncomingMessageAttachment(text: String)
+
+sealed abstract class Sender {
+  def slackReference: String
+  def plainTextReference: String
+}
+
+case class UserSender(slackUser: slack.models.User) extends Sender {
+  override def slackReference: String = s"<@${slackUser.id}>"
+  override def plainTextReference: String = slackUser.id
+}
+case class BotSender(id: String) extends Sender {
+  override def slackReference: String = s"app: $id"
+  override def plainTextReference: String = slackReference
+}
+

--- a/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
@@ -74,6 +74,7 @@ abstract class BotPlugin
   // Helpers for plugins to use.
 
   protected def sendMessage(msg: OutgoingMessage): Unit = context.system.eventStream.publish(msg)
+  protected def sendImage(im: OutgoingImage): Unit = context.system.eventStream.publish(im)
 
   class RichIncomingMessage(msg: IncomingMessage) {
     def response(text: String) = OutgoingMessage(msg.channel, responsePrefix + text)

--- a/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
@@ -85,8 +85,12 @@ abstract class BotPlugin
 
     def respond(text: String) = sendMessage(response(text))
 
-    private def responsePrefix: String = if (msg.channel.isInstanceOf[InstantMessageChannel]) ""
-                                       else s"${msg.sentBy.slackReference}: "
+    private def responsePrefix: String =
+      if (msg.channel.isInstanceOf[InstantMessageChannel]) {
+        ""
+      } else {
+        s"${msg.sentBy.slackReference}: "
+      }
 
     def scheduleResponse(delay: FiniteDuration, text: String): Unit = scheduleOutgoingMessage(delay, response(text))
 

--- a/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
@@ -84,9 +84,8 @@ abstract class BotPlugin
 
     def respond(text: String) = sendMessage(response(text))
 
-    def senderId: String = s"<@${msg.sentByUser.id}>"
-
-    private def responsePrefix: String = if (msg.channel.isInstanceOf[InstantMessageChannel]) "" else s"$senderId: "
+    private def responsePrefix: String = if (msg.channel.isInstanceOf[InstantMessageChannel]) ""
+                                       else s"${msg.sentBy.slackReference}: "
 
     def scheduleResponse(delay: FiniteDuration, text: String): Unit = scheduleOutgoingMessage(delay, response(text))
 
@@ -194,7 +193,7 @@ abstract class BotPlugin
   }
 
   protected final def initialized: Receive = {
-    case message@IncomingMessage(text, _, _, _) =>
+    case message@IncomingMessage(text, _, _, _, _) =>
       receiveIncomingMessageInternal(message)
   }
 

--- a/src/main/scala/com/sumologic/sumobot/plugins/OperatorLimits.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/OperatorLimits.scala
@@ -19,7 +19,7 @@
 package com.sumologic.sumobot.plugins
 
 import com.sumologic.sumobot.core.Bootstrap
-import com.sumologic.sumobot.core.model.IncomingMessage
+import com.sumologic.sumobot.core.model.{IncomingMessage, Sender, UserSender}
 import slack.models.User
 
 import scala.collection.JavaConverters._
@@ -27,6 +27,12 @@ import scala.collection.JavaConverters._
 object OperatorLimits {
   private val config = Bootstrap.system.settings.config
   private lazy val operatorNames = config.getStringList("operators").asScala.toSet
+
+  def isOperator(sender: Sender): Boolean =
+    sender match {
+      case u: UserSender => isOperator(u.slackUser)
+      case _ => false
+    }
 
   def isOperator(user: User): Boolean =
     operatorNames.exists(_.trim.equalsIgnoreCase(user.name.trim))
@@ -36,5 +42,5 @@ trait OperatorLimits {
   this: BotPlugin => 
   
   protected def sentByOperator(message: IncomingMessage): Boolean =
-    OperatorLimits.isOperator(message.sentByUser)
+    OperatorLimits.isOperator(message.sentBy)
 }

--- a/src/main/scala/com/sumologic/sumobot/plugins/advice/Advice.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/advice/Advice.scala
@@ -47,10 +47,10 @@ class Advice extends BotPlugin {
   import Advice._
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case msg@IncomingMessage(RandomAdvice(), _, _, _) =>
+    case msg@IncomingMessage(RandomAdvice(), _, _, _, _) =>
       msg.httpGet(s"http://api.adviceslip.com/advice")(respondWithAdvice)
 
-    case msg@IncomingMessage(AdviceAbout(_, something), true, _, _) =>
+    case msg@IncomingMessage(AdviceAbout(_, something), true, _, _, _) =>
       msg.httpGet(s"http://api.adviceslip.com/advice/search/${urlEncode(something.trim)}")(respondWithAdvice)
   }
 

--- a/src/main/scala/com/sumologic/sumobot/plugins/alias/Alias.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/alias/Alias.scala
@@ -44,7 +44,7 @@ class Alias extends BotPlugin {
   }
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(CreateAlias(from, to), _, _, _) =>
+    case message@IncomingMessage(CreateAlias(from, to), _, _, _, _) =>
       if (from.isEmpty || to.isEmpty) {
         message.respond("You've gotta give me both parts!")
       } else if (from == to) {
@@ -55,14 +55,14 @@ class Alias extends BotPlugin {
         message.respond(s"Ok, remembered that '$from' is '$to'")
       }
 
-    case message@IncomingMessage(text, _, _, _) if knownAliases.exists(_._1.equalsIgnoreCase(text)) =>
+    case message@IncomingMessage(text, _, _, _, _) if knownAliases.exists(_._1.equalsIgnoreCase(text)) =>
       knownAliases.find(_._1.equalsIgnoreCase(text)).foreach {
         tpl =>
           val replacement = tpl._2
           context.system.eventStream.publish(message.copy(canonicalText = replacement))
       }
 
-    case message@IncomingMessage(RemoveAlias(alias), _, _, _) =>
+    case message@IncomingMessage(RemoveAlias(alias), _, _, _, _) =>
       knownAliases.find(_._1.equalsIgnoreCase(alias)) match {
         case Some(knownAlias) =>
           knownAliases -= knownAlias._1
@@ -72,7 +72,7 @@ class Alias extends BotPlugin {
           message.respond(s"I don't know anything about $alias")
       }
 
-    case message@IncomingMessage(ShowAliases(alias), _, _, _) =>
+    case message@IncomingMessage(ShowAliases(alias), _, _, _, _) =>
       if (knownAliases.nonEmpty) {
         message.respond(knownAliases.toSeq.sortBy(_._1).map(tpl => s"'${tpl._1}' is '${tpl._2}'").mkString("\n"))
       } else {

--- a/src/main/scala/com/sumologic/sumobot/plugins/awssupport/AWSSupport.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/awssupport/AWSSupport.scala
@@ -55,14 +55,14 @@ class AWSSupport
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
 
-    case message@IncomingMessage(ListCases(), _, _, _) =>
+    case message@IncomingMessage(ListCases(), _, _, _, _) =>
       message.respondInFuture {
         msg =>
           val caseList = getAllCases.map(summary(_) + "\n").mkString("\n")
           msg.message(caseList)
       }
 
-    case message@IncomingMessage(CaseDetails(caseId), _, _, _) =>
+    case message@IncomingMessage(CaseDetails(caseId), _, _, _, _) =>
       message.respondInFuture {
         msg =>
           log.info(s"Looking for case $caseId")

--- a/src/main/scala/com/sumologic/sumobot/plugins/beer/Beer.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/beer/Beer.scala
@@ -43,7 +43,7 @@ class Beer extends BotPlugin with TimeHelpers {
   private var lastChimedIn = 0l
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(BeerMention(beer), _, _, _) =>
+    case message@IncomingMessage(BeerMention(beer), _, _, _, _) =>
       if (now - lastChimedIn > 60000 && Random.nextInt(10) < 8) {
         lastChimedIn = now
         message.say(chooseRandom(BeerPhrases: _*))

--- a/src/main/scala/com/sumologic/sumobot/plugins/brain/BrainSurgery.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/brain/BrainSurgery.scala
@@ -38,13 +38,13 @@ class BrainSurgery extends BotPlugin {
   private val forget = matchText("forget about ([\\.\\w]+).*")
 
   override protected def receiveIncomingMessage = {
-    case message@IncomingMessage(remember(key, value), true, _, _) =>
+    case message@IncomingMessage(remember(key, value), true, _, _, _) =>
       blockingBrain.store(key.trim, value.trim)
       message.respond(s"Got it, $key is $value")
-    case message@IncomingMessage(forget(key), true, _, _) =>
+    case message@IncomingMessage(forget(key), true, _, _, _) =>
       blockingBrain.remove(key.trim)
       message.respond(s"$key? I've forgotten all about it.")
-    case message@IncomingMessage(brainDump(), true, _, _) =>
+    case message@IncomingMessage(brainDump(), true, _, _, _) =>
       val map = blockingBrain.listValues()
       if (map.isEmpty) {
         message.say("My brain is empty.")

--- a/src/main/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorris.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorris.scala
@@ -20,7 +20,7 @@ package com.sumologic.sumobot.plugins.chuck
 
 import java.net.URLEncoder
 
-import com.sumologic.sumobot.core.model.{IncomingMessage, OutgoingMessage}
+import com.sumologic.sumobot.core.model.{IncomingMessage, OutgoingMessage, UserSender}
 import com.sumologic.sumobot.plugins.BotPlugin
 import org.apache.http.HttpResponse
 import org.apache.http.util.EntityUtils
@@ -42,13 +42,13 @@ class ChuckNorris extends BotPlugin {
   private val BaseUrl = "http://api.icndb.com/jokes/random"
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case msg@IncomingMessage(ChuckNorris(), _, _, _) =>
+    case msg@IncomingMessage(ChuckNorris(), _, _, _, _) =>
       msg.httpGet(BaseUrl)(convertResponse)
 
-    case msg@IncomingMessage(ChuckNorrisMe(), _, _, sentByUser) =>
-      msg.httpGet(url(sentByUser))(convertResponse)
+    case msg@IncomingMessage(ChuckNorrisMe(), _, _, sentByUser: UserSender, _) =>
+      msg.httpGet(url(sentByUser.slackUser))(convertResponse)
 
-    case msg@IncomingMessage(ChuckNorrisAtMention(userId), _, _, _) =>
+    case msg@IncomingMessage(ChuckNorrisAtMention(userId), _, _, _, _) =>
       userById(userId).foreach {
         user =>
           msg.httpGet(url(user))(convertResponse)

--- a/src/main/scala/com/sumologic/sumobot/plugins/conversations/Conversations.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/conversations/Conversations.scala
@@ -57,10 +57,10 @@ class Conversations extends BotPlugin with ActorLogging {
     Array("Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten")
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage("sup", true, _, _)  =>
+    case message@IncomingMessage("sup", true, _, _, _)  =>
       message.scheduleResponse(1.seconds, s"What's up homie! $cheerful")
 
-    case message@IncomingMessage(CountToN(number), true, _, _) =>
+    case message@IncomingMessage(CountToN(number), true, _, _, _) =>
       if (number.toInt > NumberStrings.length - 1) {
         message.respond(s"I can only count to ${NumberStrings.length - 1}!")
       } else {
@@ -70,7 +70,7 @@ class Conversations extends BotPlugin with ActorLogging {
         }
       }
 
-    case message@IncomingMessage(CountDownFromN(number), true, _, _) =>
+    case message@IncomingMessage(CountDownFromN(number), true, _, _, _) =>
       val start = number.toInt + 1
       if (start > NumberStrings.length) {
         message.respond(s"I can only count down from ${NumberStrings.length - 1}!")
@@ -81,35 +81,35 @@ class Conversations extends BotPlugin with ActorLogging {
         }
       }
 
-    case message@IncomingMessage(TellColon(recipientUserId, what), true, _, _) =>
+    case message@IncomingMessage(TellColon(recipientUserId, what), true, _, _, _) =>
       tell(message, recipientUserId, what)
 
-    case message@IncomingMessage(TellTo(recipientUserId, what), true, _, _) =>
+    case message@IncomingMessage(TellTo(recipientUserId, what), true, _, _, _) =>
       tell(message, recipientUserId, what)
 
-    case message@IncomingMessage(TellHe(recipientUserId, what), true, _, _) =>
+    case message@IncomingMessage(TellHe(recipientUserId, what), true, _, _, _) =>
       tell(message, recipientUserId, "you " + what)
 
-    case message@IncomingMessage(TellShe(recipientUserId, what), true, _, _) =>
+    case message@IncomingMessage(TellShe(recipientUserId, what), true, _, _, _) =>
       tell(message, recipientUserId, "you " + what)
 
-    case message@IncomingMessage(Sup(name), _, _, _) if name == state.self.name =>
+    case message@IncomingMessage(Sup(name), _, _, _, _) if name == state.self.name =>
       message.respond("What is up!!")
 
-    case message@IncomingMessage(SupAtMention(userId), _, _, _) if userId == state.self.id =>
-      message.say(s"What is up, <@${message.sentByUser.id}>.")
+    case message@IncomingMessage(SupAtMention(userId), _, _, UserSender(sentByUser), _) if userId == state.self.id =>
+      message.say(s"What is up, <@${sentByUser.id}>.")
 
-    case message@IncomingMessage(SayInChannel(channelId, what), true, _, _) =>
+    case message@IncomingMessage(SayInChannel(channelId, what), true, _, _, _) =>
       sendMessage(OutgoingMessage(Channel.forChannelId(state, channelId), what))
       message.respond(s"Message sent.")
 
-    case message@IncomingMessage(FuckOff(), _, _, _) =>
+    case message@IncomingMessage(FuckOff(), _, _, _, _) =>
       message.respond("Same to you.")
 
-    case message@IncomingMessage(FuckYou(), _, _, _) =>
+    case message@IncomingMessage(FuckYou(), _, _, _, _) =>
       message.respond("This is the worst kind of discrimination there is: the kind against me!")
 
-    case message@IncomingMessage(WhatTimeIsIt(), _, _, _) =>
+    case message@IncomingMessage(WhatTimeIsIt(), _, _, _, _) =>
       val format = DateFormat.getDateTimeInstance
       val formatted = format.format(new Date())
       message.respond(s"Here, it is $formatted")

--- a/src/main/scala/com/sumologic/sumobot/plugins/help/Help.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/help/Help.scala
@@ -43,7 +43,7 @@ class Help extends BotPlugin with ActorLogging {
   import Help._
 
   override protected def receiveIncomingMessage = {
-    case message@IncomingMessage(ListPlugins(_), true, _, _) =>
+    case message@IncomingMessage(ListPlugins(_), true, _, _, _) =>
       val msg = message
       implicit val timeout = Timeout(5.seconds)
       pluginRegistry ? RequestPluginList onSuccess {
@@ -51,7 +51,7 @@ class Help extends BotPlugin with ActorLogging {
           msg.say(plugins.map(_.plugin.path.name).sorted.mkString("\n"))
       }
 
-    case message@IncomingMessage(HelpForPlugin(_, pluginName), addressedToUs, _, _) =>
+    case message@IncomingMessage(HelpForPlugin(_, pluginName), addressedToUs, _, _, _) =>
       val msg = message
       implicit val timeout = Timeout(5.seconds)
       pluginRegistry ? RequestPluginList onSuccess {

--- a/src/main/scala/com/sumologic/sumobot/plugins/jira/Jira.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/jira/Jira.scala
@@ -80,8 +80,8 @@ class Jira extends BotPlugin with TimeHelpers with ActorLogging {
   }
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(Jira.JiraInfo(id), _, _, _) => message.respondInFuture(loadJiraInfo(_, id))
-    case message@IncomingMessage(Jira.InProgressJirasFor(username), _, _, _) => message.respondInFuture(loadInProgressJirasFor(_, username))
+    case message@IncomingMessage(Jira.JiraInfo(id), _, _, _, _) => message.respondInFuture(loadJiraInfo(_, id))
+    case message@IncomingMessage(Jira.InProgressJirasFor(username), _, _, _, _) => message.respondInFuture(loadInProgressJirasFor(_, username))
   }
 
   private def loadJiraInfo(msg: IncomingMessage, id: String): OutgoingMessage = {
@@ -93,8 +93,8 @@ class Jira extends BotPlugin with TimeHelpers with ActorLogging {
         val string =
           s"""
              |*Title:* ${issue.getSummary}\n
-                                            |*Assignee:* ${issue.getAssignee.getName}\n
-                                                                                       |*Description:* ${Option(issue.getDescription).map(_.take(MaxDescLength)).getOrElse("no description")}
+             |*Assignee:* ${issue.getAssignee.getName}\n
+             |*Description:* ${Option(issue.getDescription).map(_.take(MaxDescLength)).getOrElse("no description")}
           """.stripMargin
         msg.response(string)
       case Failure(e) =>

--- a/src/main/scala/com/sumologic/sumobot/plugins/pagerduty/PagerDuty.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/pagerduty/PagerDuty.scala
@@ -19,7 +19,7 @@
 package com.sumologic.sumobot.plugins.pagerduty
 
 import akka.actor.ActorLogging
-import com.sumologic.sumobot.core.model.{IncomingMessage, OutgoingMessage, PublicChannel}
+import com.sumologic.sumobot.core.model.{IncomingMessage, OutgoingMessage, PublicChannel, UserSender}
 import com.sumologic.sumobot.plugins.BotPlugin
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -70,13 +70,13 @@ class PagerDuty extends BotPlugin with ActorLogging {
   import PagerDuty._
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(WhosOnCall(filter), _, _, _) =>
+    case message@IncomingMessage(WhosOnCall(filter), _, _, _, _) =>
       message.respondInFuture(whoIsOnCall(_, maximumLevel, Option(filter)))
 
-    case message@IncomingMessage(PageOnCalls(text), _, PublicChannel(_, channel), _) =>
+    case message@IncomingMessage(PageOnCalls(text), _, PublicChannel(_, channel), UserSender(sentByUser), _) =>
       pagerDutyKeyFor(channel) match {
         case Some(key) =>
-          eventApi.page(channel, key, s"${message.sentByUser.name} on $channel: $text")
+          eventApi.page(channel, key, s"${sentByUser.name} on $channel: $text")
           message.say("Paged on-calls.")
         case None =>
           message.respond("Don't know how to page people in this channel.")

--- a/src/main/scala/com/sumologic/sumobot/plugins/system/System.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/system/System.scala
@@ -47,17 +47,17 @@ class System
   private val startTime = new Date().toString
 
   override protected def receiveIncomingMessage = {
-    case message@IncomingMessage(WhereAreYou(), true, _, _) =>
+    case message@IncomingMessage(WhereAreYou(), true, _, _, _) =>
       message.respond(s"I'm running at $hostname ($hostAddress)")
-    case message@IncomingMessage(WhenDidYouStart(_), true, _, _) =>
+    case message@IncomingMessage(WhenDidYouStart(_), true, _, _, _) =>
       message.respond(s"I started at $startTime")
-    case message@IncomingMessage(DieOn(host), true, _, _) =>
+    case message@IncomingMessage(DieOn(host), true, _, _, _) =>
 
       if (host.trim.equalsIgnoreCase(hostname)) {
         if (!sentByOperator(message)) {
-          message.respond(s"Sorry, ${message.senderId}, I can't do that.")
+          message.respond(s"Sorry, ${message.sentBy.slackReference}, I can't do that.")
         } else {
-          message.respond(s"Sayonara, ${message.senderId}!")
+          message.respond(s"Sayonara, ${message.sentBy.slackReference}!")
           context.system.scheduler.scheduleOnce(2.seconds, new Runnable {
             override def run() = {
               Bootstrap.shutdown()

--- a/src/main/scala/com/sumologic/sumobot/plugins/tts/TextToSpeech.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/tts/TextToSpeech.scala
@@ -44,7 +44,7 @@ class TextToSpeech extends BotPlugin {
   private val BadChars = "|\"".toCharArray.toSet
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(SaySomething(_, text), true, _, _) if executable.isDefined =>
+    case message@IncomingMessage(SaySomething(_, text), true, _, _, _) if executable.isDefined =>
       val cleanedText = text.toCharArray.filterNot(BadChars.contains).mkString
       // Deliberately blocking the actor thread here, so only one say action is happening at the same time.
       log.info(s"Speaking: $cleanedText")

--- a/src/main/scala/com/sumologic/sumobot/test/BotPluginTestKit.scala
+++ b/src/main/scala/com/sumologic/sumobot/test/BotPluginTestKit.scala
@@ -20,7 +20,7 @@ package com.sumologic.sumobot.test
 
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
-import com.sumologic.sumobot.core.model.{IncomingMessage, InstantMessageChannel, OutgoingMessage}
+import com.sumologic.sumobot.core.model.{IncomingMessage, InstantMessageChannel, OutgoingMessage, UserSender}
 import org.scalatest.BeforeAndAfterAll
 import slack.models.User
 
@@ -42,7 +42,7 @@ class BotPluginTestKit(_system: ActorSystem)
   }
 
   protected def instantMessage(text: String, user: User = mockUser("123", "jshmoe")): IncomingMessage = {
-    IncomingMessage(text, true, InstantMessageChannel("125", user), user)
+    IncomingMessage(text, true, InstantMessageChannel("125", user), UserSender(user))
   }
 
   protected def mockUser(id: String, name: String): User = {

--- a/src/test/scala/com/sumologic/sumobot/plugins/help/HelpTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/help/HelpTest.scala
@@ -19,7 +19,7 @@
 package com.sumologic.sumobot.plugins.help
 
 import akka.actor.{ActorSystem, Props}
-import com.sumologic.sumobot.core.model.{IncomingMessage, InstantMessageChannel}
+import com.sumologic.sumobot.core.model.{IncomingMessage, InstantMessageChannel, UserSender}
 import com.sumologic.sumobot.core.PluginRegistry
 import com.sumologic.sumobot.plugins.BotPlugin.{InitializePlugin, PluginAdded}
 import com.sumologic.sumobot.plugins.conversations.Conversations
@@ -42,7 +42,7 @@ class HelpTest extends BotPluginTestKit(ActorSystem("HelpTest")) {
 
   "help" should {
     "return list of plugins" in {
-      helpRef ! IncomingMessage("help", true, InstantMessageChannel("125", user), user)
+      helpRef ! IncomingMessage("help", true, InstantMessageChannel("125", user), UserSender(user), Seq())
       confirmOutgoingMessage {
         msg =>
           msg.text should be("help\nmock")
@@ -50,7 +50,7 @@ class HelpTest extends BotPluginTestKit(ActorSystem("HelpTest")) {
     }
 
     "return help for known plugins" in {
-      helpRef ! IncomingMessage("help mock", true, InstantMessageChannel("125", user), user)
+      helpRef ! IncomingMessage("help mock", true, InstantMessageChannel("125", user), UserSender(user), Seq())
       confirmOutgoingMessage {
         msg =>
           msg.text should include("mock help")
@@ -58,7 +58,7 @@ class HelpTest extends BotPluginTestKit(ActorSystem("HelpTest")) {
     }
 
     "return an error for unknown commands" in {
-      helpRef ! IncomingMessage("help test", true, InstantMessageChannel("125", user), user)
+      helpRef ! IncomingMessage("help test", true, InstantMessageChannel("125", user), UserSender(user), Seq())
       confirmOutgoingMessage {
         msg =>
           msg.text should include("Sorry, I don't know")


### PR DESCRIPTION
- Introducing ability to read messages from bots, not only form users.
- Moreover, using the fork of the upstream `slack-sumo-client`, adding the ability to retrieve attachments of the messages the bot send: `UserSender` vs. `BotSender`
- Adding the ability to send images 