### PR TITLE
Read timeStamp of parent which is sent in case of slack threads

### DIFF
--- a/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
@@ -108,44 +108,46 @@ class Receptionist(rtmClient: SlackRtmClient,
       pendingIMSessionsByUserId = pendingIMSessionsByUserId + (userId -> (doneRecipient, doneMessage))
 
     case message: Message if !tooOld(message.ts, message) =>
-      translateAndDispatch(message.channel, message.user, message.text, message.ts, parentTimeStamp = message.thread_ts)
+      translateAndDispatch(message.channel, message.user, message.text, message.ts, threadTimestamp = message.thread_ts)
 
     case messageChanged: MessageChanged if !tooOld(messageChanged.ts, messageChanged) =>
       val message = messageChanged.message
       translateAndDispatch(messageChanged.channel, message.user, message.text, message.ts)
 
     case botMessage: BotMessage if !tooOld(botMessage.ts, botMessage) && botMessage.username.isDefined =>
-      translateAndDispatch(botMessage.channel, botMessage.username.get, botMessage.text, botMessage.ts,
-        fromBot = true,
-        botMessage.attachments)
+      translateAndDispatch(botMessage.channel, botMessage.username.get, botMessage.text, botMessage.ts, attachments = botMessage.attachments, fromBot = true)
 
     case RtmStateRequest(sendTo) =>
       sendTo ! RtmStateResponse(rtmClient.state)
   }
 
-  protected def translateMessage(channelId: String, idTimestamp: String, from: Sender, text: String,
+  protected def translateMessage(channelId: String,
+                                 idTimestamp: String,
+                                 threadTimestamp: Option[String] = None,
+                                 text: String,
                                  attachments: Seq[IncomingMessageAttachment],
-                                 parentTimeStamp: Option[String] = None): IncomingMessage = {
+                                 from: Sender): IncomingMessage = {
     val channel = Channel.forChannelId(rtmClient.state, channelId)
 
     text match {
       case atMention(user, text) if user == selfId =>
-        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments, parentTimeStamp)
+        IncomingMessage(text.trim, true, channel, idTimestamp, threadTimestamp, attachments, from)
       case atMentionWithoutColon(user, text) if user == selfId =>
-        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments, parentTimeStamp)
+        IncomingMessage(text.trim, true, channel, idTimestamp, threadTimestamp, attachments, from)
       case simpleNamePrefix(name, text) if name.equalsIgnoreCase(selfName) =>
-        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments, parentTimeStamp)
+        IncomingMessage(text.trim, true, channel, idTimestamp, threadTimestamp, attachments, from)
       case _ =>
-        IncomingMessage(text.trim, channel.isInstanceOf[InstantMessageChannel], channel, idTimestamp,
-          from, attachments, parentTimeStamp)
+        IncomingMessage(text.trim, channel.isInstanceOf[InstantMessageChannel], channel, idTimestamp, threadTimestamp, attachments, from)
     }
   }
 
-  private def translateAndDispatch(channelId: String, userId: String, text: String,
+  private def translateAndDispatch(channelId: String,
+                                   userId: String,
+                                   text: String,
                                    idTimestamp: String,
-                                   fromBot: Boolean = false,
+                                   threadTimestamp: Option[String] = None,
                                    attachments: Seq[Attachment] = Seq(),
-                                   parentTimeStamp: Option[String] = None): Unit = {
+                                   fromBot: Boolean = false): Unit = {
     val sentBy: Sender = if (!fromBot) {
       val slackUser: slack.models.User = rtmClient.state.users.find(_.id == userId).
         getOrElse(throw new IllegalStateException(s"Message from unknown user: $userId"))
@@ -153,8 +155,7 @@ class Receptionist(rtmClient: SlackRtmClient,
     } else {
       BotSender(userId)
     }
-    val msgToBot = translateMessage(channelId, idTimestamp, sentBy, text,
-      attachments.map(a => IncomingMessageAttachment(a.text.getOrElse(""))), parentTimeStamp)
+    val msgToBot = translateMessage(channelId, idTimestamp, threadTimestamp, text, attachments.map(a => IncomingMessageAttachment(a.text.getOrElse(""))), sentBy)
     if (userId != selfId) {
       log.info(s"Dispatching message: $msgToBot")
       context.system.eventStream.publish(msgToBot)
@@ -166,7 +167,7 @@ class Receptionist(rtmClient: SlackRtmClient,
   private def tooOld(ts: String, message: AnyRef): Boolean = {
     ts match {
       case tsPattern(timeOfMessage, _) =>
-        val oldestAllowableMessageTime = (System.currentTimeMillis() - messageAgeLimitMillis)/1000
+        val oldestAllowableMessageTime = (System.currentTimeMillis() - messageAgeLimitMillis) / 1000
         val messageTooOld = timeOfMessage.toLong < oldestAllowableMessageTime
         if (messageTooOld) {
           log.warning(s"Discarding old message ($ts is too old, cutoff is $oldestAllowableMessageTime): $message")

--- a/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
@@ -18,14 +18,12 @@
  */
 package com.sumologic.sumobot.core
 
-import java.io.File
-
 import akka.actor._
 import com.sumologic.sumobot.core.Receptionist.{RtmStateRequest, RtmStateResponse}
 import com.sumologic.sumobot.core.model.{IncomingMessageAttachment, _}
 import com.sumologic.sumobot.plugins.BotPlugin.{InitializePlugin, PluginAdded, PluginRemoved}
 import slack.api.{BlockingSlackApiClient, SlackApiClient}
-import slack.models.{ActionField, Attachment, BotMessage, ImOpened, Message, MessageChanged, User}
+import slack.models.{Attachment, BotMessage, ImOpened, Message, MessageChanged}
 import slack.rtm.{RtmState, SlackRtmClient}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -110,41 +108,44 @@ class Receptionist(rtmClient: SlackRtmClient,
       pendingIMSessionsByUserId = pendingIMSessionsByUserId + (userId -> (doneRecipient, doneMessage))
 
     case message: Message if !tooOld(message.ts, message) =>
-      translateAndDispatch(message.channel, message.user, message.text, message.ts)
+      translateAndDispatch(message.channel, message.user, message.text, message.ts, parentTimeStamp = message.thread_ts)
 
     case messageChanged: MessageChanged if !tooOld(messageChanged.ts, messageChanged) =>
       val message = messageChanged.message
       translateAndDispatch(messageChanged.channel, message.user, message.text, message.ts)
 
     case botMessage: BotMessage if !tooOld(botMessage.ts, botMessage) && botMessage.username.isDefined =>
-        translateAndDispatch(botMessage.channel, botMessage.username.get, botMessage.text, botMessage.ts,
-                             fromBot = true,
-                             botMessage.attachments)
+      translateAndDispatch(botMessage.channel, botMessage.username.get, botMessage.text, botMessage.ts,
+        fromBot = true,
+        botMessage.attachments)
 
     case RtmStateRequest(sendTo) =>
       sendTo ! RtmStateResponse(rtmClient.state)
   }
 
   protected def translateMessage(channelId: String, idTimestamp: String, from: Sender, text: String,
-                                 attachments: Seq[IncomingMessageAttachment]): IncomingMessage = {
+                                 attachments: Seq[IncomingMessageAttachment],
+                                 parentTimeStamp: Option[String] = None): IncomingMessage = {
     val channel = Channel.forChannelId(rtmClient.state, channelId)
 
     text match {
       case atMention(user, text) if user == selfId =>
-        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments)
+        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments, parentTimeStamp)
       case atMentionWithoutColon(user, text) if user == selfId =>
-        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments)
+        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments, parentTimeStamp)
       case simpleNamePrefix(name, text) if name.equalsIgnoreCase(selfName) =>
-        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments)
+        IncomingMessage(text.trim, true, channel, idTimestamp, from, attachments, parentTimeStamp)
       case _ =>
-        IncomingMessage(text.trim, channel.isInstanceOf[InstantMessageChannel], channel, idTimestamp, from, attachments)
+        IncomingMessage(text.trim, channel.isInstanceOf[InstantMessageChannel], channel, idTimestamp,
+          from, attachments, parentTimeStamp)
     }
   }
 
   private def translateAndDispatch(channelId: String, userId: String, text: String,
                                    idTimestamp: String,
                                    fromBot: Boolean = false,
-                                   attachments: Seq[Attachment] = Seq()): Unit = {
+                                   attachments: Seq[Attachment] = Seq(),
+                                   parentTimeStamp: Option[String] = None): Unit = {
     val sentBy: Sender = if (!fromBot) {
       val slackUser: slack.models.User = rtmClient.state.users.find(_.id == userId).
         getOrElse(throw new IllegalStateException(s"Message from unknown user: $userId"))
@@ -152,7 +153,8 @@ class Receptionist(rtmClient: SlackRtmClient,
     } else {
       BotSender(userId)
     }
-    val msgToBot = translateMessage(channelId, idTimestamp, sentBy, text, attachments.map(a => IncomingMessageAttachment(a.text.getOrElse(""))))
+    val msgToBot = translateMessage(channelId, idTimestamp, sentBy, text,
+      attachments.map(a => IncomingMessageAttachment(a.text.getOrElse(""))), parentTimeStamp)
     if (userId != selfId) {
       log.info(s"Dispatching message: $msgToBot")
       context.system.eventStream.publish(msgToBot)

--- a/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
@@ -30,9 +30,9 @@ case class IncomingMessage(canonicalText: String,
                            addressedToUs: Boolean,
                            channel: Channel,
                            idTimestamp: String,
-                           sentBy: Sender,
+                           threadTimestamp: Option[String] = None,
                            attachments: Seq[IncomingMessageAttachment] = Seq(),
-                           parentTimeStamp: Option[String] = None)
+                           sentBy: Sender)
 
 case class IncomingMessageAttachment(text: String)
 

--- a/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
@@ -21,7 +21,6 @@ package com.sumologic.sumobot.core.model
 import java.io.File
 
 import akka.actor.ActorRef
-import slack.models.User
 
 case class OutgoingMessage(channel: Channel, text: String, threadTs: Option[String] = None)
 
@@ -32,7 +31,8 @@ case class IncomingMessage(canonicalText: String,
                            channel: Channel,
                            idTimestamp: String,
                            sentBy: Sender,
-                           attachments: Seq[IncomingMessageAttachment] = Seq())
+                           attachments: Seq[IncomingMessageAttachment] = Seq(),
+                           parentTimeStamp: Option[String] = None)
 
 case class IncomingMessageAttachment(text: String)
 

--- a/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
@@ -27,7 +27,6 @@ import com.sumologic.sumobot.core.model._
 import com.sumologic.sumobot.plugins.BotPlugin.{InitializePlugin, PluginAdded, PluginRemoved}
 import com.sumologic.sumobot.quartz.QuartzExtension
 import com.typesafe.config.Config
-import org.apache.commons.lang.StringUtils
 import org.apache.http.HttpResponse
 import org.apache.http.client.methods.{HttpGet, HttpUriRequest}
 import org.apache.http.impl.client.DefaultHttpClient
@@ -55,8 +54,8 @@ object BotPlugin {
 
 abstract class BotPlugin
   extends Actor
-  with ActorLogging
-  with Emotions {
+    with ActorLogging
+    with Emotions {
 
   type ReceiveIncomingMessage = PartialFunction[IncomingMessage, Unit]
 
@@ -75,11 +74,16 @@ abstract class BotPlugin
   // Helpers for plugins to use.
 
   protected def sendMessage(msg: OutgoingMessage): Unit = context.system.eventStream.publish(msg)
+
   protected def sendImage(im: OutgoingImage): Unit = context.system.eventStream.publish(im)
 
   class RichIncomingMessage(msg: IncomingMessage) {
     def response(text: String, inThread: Boolean = false) = {
-      val threadTs = if (inThread) { Some(msg.idTimestamp) } else { None }
+      val threadTs = if (inThread) {
+        Some(msg.idTimestamp)
+      } else {
+        None
+      }
       OutgoingMessage(msg.channel, responsePrefix(inThread) + text, threadTs)
     }
 
@@ -105,7 +109,7 @@ abstract class BotPlugin
         override def run(): Unit = sendMessage(outgoingMessage)
       })
     }
-    
+
     def respondInFuture(body: IncomingMessage => OutgoingMessage)(implicit executor: scala.concurrent.ExecutionContext): Unit = {
       Future {
         try {
@@ -202,7 +206,7 @@ abstract class BotPlugin
   }
 
   protected final def initialized: Receive = {
-    case message@IncomingMessage(text, _, _, _, _, _) =>
+    case message@IncomingMessage(text, _, _, _, _, _, _) =>
       receiveIncomingMessageInternal(message)
   }
 

--- a/src/main/scala/com/sumologic/sumobot/plugins/advice/Advice.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/advice/Advice.scala
@@ -47,10 +47,10 @@ class Advice extends BotPlugin {
   import Advice._
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case msg@IncomingMessage(RandomAdvice(), _, _, _, _, _) =>
+    case msg@IncomingMessage(RandomAdvice(), _, _, _, _, _, _) =>
       msg.httpGet(s"http://api.adviceslip.com/advice")(respondWithAdvice)
 
-    case msg@IncomingMessage(AdviceAbout(_, something), true, _, _, _, _) =>
+    case msg@IncomingMessage(AdviceAbout(_, something), true, _, _, _, _, _) =>
       msg.httpGet(s"http://api.adviceslip.com/advice/search/${urlEncode(something.trim)}")(respondWithAdvice)
   }
 

--- a/src/main/scala/com/sumologic/sumobot/plugins/alias/Alias.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/alias/Alias.scala
@@ -44,7 +44,7 @@ class Alias extends BotPlugin {
   }
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(CreateAlias(from, to), _, _, _, _, _) =>
+    case message@IncomingMessage(CreateAlias(from, to), _, _, _, _, _, _) =>
       if (from.isEmpty || to.isEmpty) {
         message.respond("You've gotta give me both parts!")
       } else if (from == to) {
@@ -55,14 +55,14 @@ class Alias extends BotPlugin {
         message.respond(s"Ok, remembered that '$from' is '$to'")
       }
 
-    case message@IncomingMessage(text, _, _, _, _, _) if knownAliases.exists(_._1.equalsIgnoreCase(text)) =>
+    case message@IncomingMessage(text, _, _, _, _, _, _) if knownAliases.exists(_._1.equalsIgnoreCase(text)) =>
       knownAliases.find(_._1.equalsIgnoreCase(text)).foreach {
         tpl =>
           val replacement = tpl._2
           context.system.eventStream.publish(message.copy(canonicalText = replacement))
       }
 
-    case message@IncomingMessage(RemoveAlias(alias), _, _, _, _, _) =>
+    case message@IncomingMessage(RemoveAlias(alias), _, _, _, _, _, _) =>
       knownAliases.find(_._1.equalsIgnoreCase(alias)) match {
         case Some(knownAlias) =>
           knownAliases -= knownAlias._1
@@ -72,7 +72,7 @@ class Alias extends BotPlugin {
           message.respond(s"I don't know anything about $alias")
       }
 
-    case message@IncomingMessage(ShowAliases(alias), _, _, _, _, _) =>
+    case message@IncomingMessage(ShowAliases(alias), _, _, _, _, _, _) =>
       if (knownAliases.nonEmpty) {
         message.respond(knownAliases.toSeq.sortBy(_._1).map(tpl => s"'${tpl._1}' is '${tpl._2}'").mkString("\n"))
       } else {

--- a/src/main/scala/com/sumologic/sumobot/plugins/awssupport/AWSSupport.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/awssupport/AWSSupport.scala
@@ -32,7 +32,7 @@ import scala.util.{Failure, Success, Try}
 
 class AWSSupport
   extends BotPlugin
-  with ActorLogging {
+    with ActorLogging {
 
   case class CaseInAccount(account: String, caseDetails: CaseDetails)
 
@@ -55,14 +55,14 @@ class AWSSupport
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
 
-    case message@IncomingMessage(ListCases(), _, _, _, _, _) =>
+    case message@IncomingMessage(ListCases(), _, _, _, _, _, _) =>
       message.respondInFuture {
         msg =>
           val caseList = getAllCases.map(summary(_) + "\n").mkString("\n")
           msg.message(caseList)
       }
 
-    case message@IncomingMessage(CaseDetails(caseId), _, _, _, _, _) =>
+    case message@IncomingMessage(CaseDetails(caseId), _, _, _, _, _, _) =>
       message.respondInFuture {
         msg =>
           log.info(s"Looking for case $caseId")

--- a/src/main/scala/com/sumologic/sumobot/plugins/beer/Beer.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/beer/Beer.scala
@@ -43,7 +43,7 @@ class Beer extends BotPlugin with TimeHelpers {
   private var lastChimedIn = 0l
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(BeerMention(beer), _, _, _, _, _) =>
+    case message@IncomingMessage(BeerMention(beer), _, _, _, _, _, _) =>
       if (now - lastChimedIn > 60000 && Random.nextInt(10) < 8) {
         lastChimedIn = now
         message.say(chooseRandom(BeerPhrases: _*))

--- a/src/main/scala/com/sumologic/sumobot/plugins/brain/BrainSurgery.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/brain/BrainSurgery.scala
@@ -38,13 +38,13 @@ class BrainSurgery extends BotPlugin {
   private val forget = matchText("forget about ([\\.\\w]+).*")
 
   override protected def receiveIncomingMessage = {
-    case message@IncomingMessage(remember(key, value), true, _, _, _, _) =>
+    case message@IncomingMessage(remember(key, value), true, _, _, _, _,_) =>
       blockingBrain.store(key.trim, value.trim)
       message.respond(s"Got it, $key is $value")
-    case message@IncomingMessage(forget(key), true, _, _, _, _) =>
+    case message@IncomingMessage(forget(key), true, _, _, _, _, _) =>
       blockingBrain.remove(key.trim)
       message.respond(s"$key? I've forgotten all about it.")
-    case message@IncomingMessage(brainDump(), true, _, _, _, _) =>
+    case message@IncomingMessage(brainDump(), true, _, _, _, _, _) =>
       val map = blockingBrain.listValues()
       if (map.isEmpty) {
         message.say("My brain is empty.")

--- a/src/main/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorris.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorris.scala
@@ -45,7 +45,7 @@ class ChuckNorris extends BotPlugin {
     case msg@IncomingMessage(ChuckNorris(), _, _, _, _, _, _) =>
       msg.httpGet(BaseUrl)(convertResponse)
 
-    case msg@IncomingMessage(ChuckNorrisMe(), _, _, _, sentByUser: UserSender, _, _) =>
+    case msg@IncomingMessage(ChuckNorrisMe(), _, _, _, _, _, sentByUser: UserSender) =>
       msg.httpGet(url(sentByUser.slackUser))(convertResponse)
 
     case msg@IncomingMessage(ChuckNorrisAtMention(userId), _, _, _, _, _, _) =>

--- a/src/main/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorris.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/chuck/ChuckNorris.scala
@@ -42,13 +42,13 @@ class ChuckNorris extends BotPlugin {
   private val BaseUrl = "http://api.icndb.com/jokes/random"
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case msg@IncomingMessage(ChuckNorris(), _, _, _, _, _) =>
+    case msg@IncomingMessage(ChuckNorris(), _, _, _, _, _, _) =>
       msg.httpGet(BaseUrl)(convertResponse)
 
-    case msg@IncomingMessage(ChuckNorrisMe(), _, _, _, sentByUser: UserSender, _) =>
+    case msg@IncomingMessage(ChuckNorrisMe(), _, _, _, sentByUser: UserSender, _, _) =>
       msg.httpGet(url(sentByUser.slackUser))(convertResponse)
 
-    case msg@IncomingMessage(ChuckNorrisAtMention(userId), _, _, _, _, _) =>
+    case msg@IncomingMessage(ChuckNorrisAtMention(userId), _, _, _, _, _, _) =>
       userById(userId).foreach {
         user =>
           msg.httpGet(url(user))(convertResponse)

--- a/src/main/scala/com/sumologic/sumobot/plugins/conversations/Conversations.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/conversations/Conversations.scala
@@ -22,7 +22,6 @@ import java.text.DateFormat
 import java.util.Date
 
 import akka.actor.ActorLogging
-import com.sumologic.sumobot.core._
 import com.sumologic.sumobot.core.model._
 import com.sumologic.sumobot.plugins.BotPlugin
 
@@ -57,10 +56,10 @@ class Conversations extends BotPlugin with ActorLogging {
     Array("Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten")
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage("sup", true, _, _, _, _)  =>
+    case message@IncomingMessage("sup", true, _, _, _, _, _) =>
       message.scheduleResponse(1.seconds, s"What's up homie! $cheerful")
 
-    case message@IncomingMessage(CountToN(number), true, _, _, _, _) =>
+    case message@IncomingMessage(CountToN(number), true, _, _, _, _, _) =>
       if (number.toInt > NumberStrings.length - 1) {
         message.respond(s"I can only count to ${NumberStrings.length - 1}!")
       } else {
@@ -70,7 +69,7 @@ class Conversations extends BotPlugin with ActorLogging {
         }
       }
 
-    case message@IncomingMessage(CountDownFromN(number), true, _, _, _ , _) =>
+    case message@IncomingMessage(CountDownFromN(number), true, _, _, _, _, _) =>
       val start = number.toInt + 1
       if (start > NumberStrings.length) {
         message.respond(s"I can only count down from ${NumberStrings.length - 1}!")
@@ -81,35 +80,35 @@ class Conversations extends BotPlugin with ActorLogging {
         }
       }
 
-    case message@IncomingMessage(TellColon(recipientUserId, what), true, _, _, _ , _) =>
+    case message@IncomingMessage(TellColon(recipientUserId, what), true, _, _, _, _, _) =>
       tell(message, recipientUserId, what)
 
-    case message@IncomingMessage(TellTo(recipientUserId, what), true, _, _, _ , _) =>
+    case message@IncomingMessage(TellTo(recipientUserId, what), true, _, _, _, _, _) =>
       tell(message, recipientUserId, what)
 
-    case message@IncomingMessage(TellHe(recipientUserId, what), true, _, _, _ , _) =>
+    case message@IncomingMessage(TellHe(recipientUserId, what), true, _, _, _, _, _) =>
       tell(message, recipientUserId, "you " + what)
 
-    case message@IncomingMessage(TellShe(recipientUserId, what), true, _, _, _ , _) =>
+    case message@IncomingMessage(TellShe(recipientUserId, what), true, _, _, _, _, _) =>
       tell(message, recipientUserId, "you " + what)
 
-    case message@IncomingMessage(Sup(name), _, _, _ , _, _) if name == state.self.name =>
+    case message@IncomingMessage(Sup(name), _, _, _, _, _, _) if name == state.self.name =>
       message.respond("What is up!!")
 
-    case message@IncomingMessage(SupAtMention(userId), _, _, _, UserSender(sentByUser), _) if userId == state.self.id =>
+    case message@IncomingMessage(SupAtMention(userId), _, _, _, UserSender(sentByUser), _, _) if userId == state.self.id =>
       message.say(s"What is up, <@${sentByUser.id}>.")
 
-    case message@IncomingMessage(SayInChannel(channelId, what), true, _, _, _ , _) =>
+    case message@IncomingMessage(SayInChannel(channelId, what), true, _, _, _, _, _) =>
       sendMessage(OutgoingMessage(Channel.forChannelId(state, channelId), what))
       message.respond(s"Message sent.")
 
-    case message@IncomingMessage(FuckOff(), _, _, _ , _, _) =>
+    case message@IncomingMessage(FuckOff(), _, _, _, _, _, _) =>
       message.respond("Same to you.")
 
-    case message@IncomingMessage(FuckYou(), _, _, _ , _, _) =>
+    case message@IncomingMessage(FuckYou(), _, _, _, _, _, _) =>
       message.respond("This is the worst kind of discrimination there is: the kind against me!")
 
-    case message@IncomingMessage(WhatTimeIsIt(), _, _, _ , _, _) =>
+    case message@IncomingMessage(WhatTimeIsIt(), _, _, _, _, _, _) =>
       val format = DateFormat.getDateTimeInstance
       val formatted = format.format(new Date())
       message.respond(s"Here, it is $formatted")

--- a/src/main/scala/com/sumologic/sumobot/plugins/conversations/Conversations.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/conversations/Conversations.scala
@@ -95,7 +95,7 @@ class Conversations extends BotPlugin with ActorLogging {
     case message@IncomingMessage(Sup(name), _, _, _, _, _, _) if name == state.self.name =>
       message.respond("What is up!!")
 
-    case message@IncomingMessage(SupAtMention(userId), _, _, _, UserSender(sentByUser), _, _) if userId == state.self.id =>
+    case message@IncomingMessage(SupAtMention(userId), _, _, _, _, _, UserSender(sentByUser)) if userId == state.self.id =>
       message.say(s"What is up, <@${sentByUser.id}>.")
 
     case message@IncomingMessage(SayInChannel(channelId, what), true, _, _, _, _, _) =>

--- a/src/main/scala/com/sumologic/sumobot/plugins/help/Help.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/help/Help.scala
@@ -21,11 +21,12 @@ package com.sumologic.sumobot.plugins.help
 import akka.actor.ActorLogging
 import akka.pattern.ask
 import akka.util.Timeout
-import com.sumologic.sumobot.core.PluginRegistry.{RequestPluginList, PluginList}
+import com.sumologic.sumobot.core.PluginRegistry.{PluginList, RequestPluginList}
 import com.sumologic.sumobot.core.model.IncomingMessage
 import com.sumologic.sumobot.plugins.BotPlugin
-import scala.concurrent.duration._
+
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 object Help {
   private[help] val ListPlugins = BotPlugin.matchText("(help|\\?)\\W*")
@@ -43,7 +44,7 @@ class Help extends BotPlugin with ActorLogging {
   import Help._
 
   override protected def receiveIncomingMessage = {
-    case message@IncomingMessage(ListPlugins(_), true, _, _, _, _) =>
+    case message@IncomingMessage(ListPlugins(_), true, _, _, _, _, _) =>
       val msg = message
       implicit val timeout = Timeout(5.seconds)
       pluginRegistry ? RequestPluginList onSuccess {
@@ -51,7 +52,7 @@ class Help extends BotPlugin with ActorLogging {
           msg.say(plugins.map(_.plugin.path.name).sorted.mkString("\n"))
       }
 
-    case message@IncomingMessage(HelpForPlugin(_, pluginName), addressedToUs, _, _, _, _) =>
+    case message@IncomingMessage(HelpForPlugin(_, pluginName), addressedToUs, _, _, _, _, _) =>
       val msg = message
       implicit val timeout = Timeout(5.seconds)
       pluginRegistry ? RequestPluginList onSuccess {

--- a/src/main/scala/com/sumologic/sumobot/plugins/jenkins/Jenkins.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/jenkins/Jenkins.scala
@@ -26,13 +26,13 @@ import com.sumologic.sumobot.core.model.{Channel, IncomingMessage, OutgoingMessa
 import com.sumologic.sumobot.plugins.BotPlugin
 import com.sumologic.sumobot.plugins.jenkins.JenkinsJobMonitor.InspectJobs
 
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 class Jenkins
   extends BotPlugin
-  with JenkinsJobHelpers
-  with ActorLogging {
+    with JenkinsJobHelpers
+    with ActorLogging {
 
   private case object PollJobs
 
@@ -59,10 +59,10 @@ $name unmonitor <jobname> - I'll stop bugging you about that job."""
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
 
-    case message@IncomingMessage(Info(), _, _, _, _, _) =>
+    case message@IncomingMessage(Info(), _, _, _, _, _, _) =>
       message.respond(s"Connected to ${client.configuration.url}")
 
-    case message@IncomingMessage(JobStatus(givenName), _, _, _, _, _) =>
+    case message@IncomingMessage(JobStatus(givenName), _, _, _, _, _, _) =>
       message.respondInFuture {
         msg =>
           withKnownJob(msg, givenName) {
@@ -71,14 +71,14 @@ $name unmonitor <jobname> - I'll stop bugging you about that job."""
           }
       }
 
-    case message@IncomingMessage(BuildJob(givenName), _, _, _, UserSender(user), _) =>
+    case message@IncomingMessage(BuildJob(givenName), _, _, _, UserSender(user), _, _) =>
       val cause = URLEncoder.encode(s"Triggered via sumobot by ${user.name} in ${message.channel.name}", "UTF-8")
       message.respondInFuture {
         msg =>
           msg.response(client.buildJob(givenName, cause))
       }
 
-    case message@IncomingMessage(MonitorJob(givenName), _, _, _, _, _) =>
+    case message@IncomingMessage(MonitorJob(givenName), _, _, _, _, _, _) =>
       message.respondInFuture {
         msg =>
           withKnownJob(msg, givenName) {
@@ -98,7 +98,7 @@ $name unmonitor <jobname> - I'll stop bugging you about that job."""
           }
       }
 
-    case message@IncomingMessage(UnmonitorJob(givenName), _, _, _, _, _) =>
+    case message@IncomingMessage(UnmonitorJob(givenName), _, _, _, _, _, _) =>
       monitoredJobs.find(_._1.equalsIgnoreCase(monitorKey(message.channel, givenName.trim))) match {
         case Some(monitoredJob) =>
           monitoredJobs -= monitoredJob._1

--- a/src/main/scala/com/sumologic/sumobot/plugins/jenkins/Jenkins.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/jenkins/Jenkins.scala
@@ -71,7 +71,7 @@ $name unmonitor <jobname> - I'll stop bugging you about that job."""
           }
       }
 
-    case message@IncomingMessage(BuildJob(givenName), _, _, _, UserSender(user), _, _) =>
+    case message@IncomingMessage(BuildJob(givenName), _, _, _, _, _, UserSender(user)) =>
       val cause = URLEncoder.encode(s"Triggered via sumobot by ${user.name} in ${message.channel.name}", "UTF-8")
       message.respondInFuture {
         msg =>

--- a/src/main/scala/com/sumologic/sumobot/plugins/pagerduty/PagerDuty.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/pagerduty/PagerDuty.scala
@@ -73,7 +73,7 @@ class PagerDuty extends BotPlugin with ActorLogging {
     case message@IncomingMessage(WhosOnCall(filter), _, _, _, _, _, _) =>
       message.respondInFuture(whoIsOnCall(_, maximumLevel, Option(filter)))
 
-    case message@IncomingMessage(PageOnCalls(text), _, PublicChannel(_, channel), _, UserSender(sentByUser), _, _) =>
+    case message@IncomingMessage(PageOnCalls(text), _, PublicChannel(_, channel), _, _, _, UserSender(sentByUser)) =>
       pagerDutyKeyFor(channel) match {
         case Some(key) =>
           eventApi.page(channel, key, s"${sentByUser.name} on $channel: $text")

--- a/src/main/scala/com/sumologic/sumobot/plugins/pagerduty/PagerDuty.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/pagerduty/PagerDuty.scala
@@ -70,10 +70,10 @@ class PagerDuty extends BotPlugin with ActorLogging {
   import PagerDuty._
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(WhosOnCall(filter), _, _, _, _, _) =>
+    case message@IncomingMessage(WhosOnCall(filter), _, _, _, _, _, _) =>
       message.respondInFuture(whoIsOnCall(_, maximumLevel, Option(filter)))
 
-    case message@IncomingMessage(PageOnCalls(text), _, PublicChannel(_, channel), _, UserSender(sentByUser), _) =>
+    case message@IncomingMessage(PageOnCalls(text), _, PublicChannel(_, channel), _, UserSender(sentByUser), _, _) =>
       pagerDutyKeyFor(channel) match {
         case Some(key) =>
           eventApi.page(channel, key, s"${sentByUser.name} on $channel: $text")

--- a/src/main/scala/com/sumologic/sumobot/plugins/system/System.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/system/System.scala
@@ -20,15 +20,16 @@ package com.sumologic.sumobot.plugins.system
 
 import java.net.InetAddress
 import java.util.Date
+
 import com.sumologic.sumobot.core.Bootstrap
 import com.sumologic.sumobot.core.model.IncomingMessage
-import com.sumologic.sumobot.plugins.{OperatorLimits, BotPlugin}
-import scala.concurrent.ExecutionContext.Implicits.global
+import com.sumologic.sumobot.plugins.{BotPlugin, OperatorLimits}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class System
-    extends BotPlugin
+  extends BotPlugin
     with OperatorLimits {
   override protected def help =
     """Low-level system stuff:
@@ -47,11 +48,11 @@ class System
   private val startTime = new Date().toString
 
   override protected def receiveIncomingMessage = {
-    case message@IncomingMessage(WhereAreYou(), true, _, _, _, _) =>
+    case message@IncomingMessage(WhereAreYou(), true, _, _, _, _, _) =>
       message.respond(s"I'm running at $hostname ($hostAddress)")
-    case message@IncomingMessage(WhenDidYouStart(_), true, _, _, _, _) =>
+    case message@IncomingMessage(WhenDidYouStart(_), true, _, _, _, _, _) =>
       message.respond(s"I started at $startTime")
-    case message@IncomingMessage(DieOn(host), true, _, _, _, _) =>
+    case message@IncomingMessage(DieOn(host), true, _, _, _, _, _) =>
 
       if (host.trim.equalsIgnoreCase(hostname)) {
         if (!sentByOperator(message)) {

--- a/src/main/scala/com/sumologic/sumobot/plugins/tts/TextToSpeech.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/tts/TextToSpeech.scala
@@ -20,7 +20,6 @@ package com.sumologic.sumobot.plugins.tts
 
 import java.io.File
 
-import akka.actor.Props
 import com.sumologic.sumobot.core.model.IncomingMessage
 import com.sumologic.sumobot.plugins.BotPlugin
 
@@ -44,7 +43,7 @@ class TextToSpeech extends BotPlugin {
   private val BadChars = "|\"".toCharArray.toSet
 
   override protected def receiveIncomingMessage: ReceiveIncomingMessage = {
-    case message@IncomingMessage(SaySomething(_, text), true, _, _, _, _) if executable.isDefined =>
+    case message@IncomingMessage(SaySomething(_, text), true, _, _, _, _, _) if executable.isDefined =>
       val cleanedText = text.toCharArray.filterNot(BadChars.contains).mkString
       // Deliberately blocking the actor thread here, so only one say action is happening at the same time.
       log.info(s"Speaking: $cleanedText")

--- a/src/main/scala/com/sumologic/sumobot/test/BotPluginTestKit.scala
+++ b/src/main/scala/com/sumologic/sumobot/test/BotPluginTestKit.scala
@@ -42,7 +42,7 @@ class BotPluginTestKit(_system: ActorSystem)
   }
 
   protected def instantMessage(text: String, user: User = mockUser("123", "jshmoe")): IncomingMessage = {
-    IncomingMessage(text, true, InstantMessageChannel("125", user), "1527239216000090", UserSender(user))
+    IncomingMessage(text, true, InstantMessageChannel("125", user), "1527239216000090", sentBy = UserSender(user))
   }
 
   protected def mockUser(id: String, name: String): User = {

--- a/src/test/scala/com/sumologic/sumobot/plugins/help/HelpTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/plugins/help/HelpTest.scala
@@ -42,7 +42,7 @@ class HelpTest extends BotPluginTestKit(ActorSystem("HelpTest")) {
 
   "help" should {
     "return list of plugins" in {
-      helpRef ! IncomingMessage("help", true, InstantMessageChannel("125", user), "1527239216000090", UserSender(user), Seq())
+      helpRef ! IncomingMessage("help", true, InstantMessageChannel("125", user), "1527239216000090", attachments = Seq(), sentBy = UserSender(user))
       confirmOutgoingMessage {
         msg =>
           msg.text should be("help\nmock")
@@ -50,7 +50,7 @@ class HelpTest extends BotPluginTestKit(ActorSystem("HelpTest")) {
     }
 
     "return help for known plugins" in {
-      helpRef ! IncomingMessage("help mock", true, InstantMessageChannel("125", user), "1527239216000090", UserSender(user), Seq())
+      helpRef ! IncomingMessage("help mock", true, InstantMessageChannel("125", user), "1527239216000090", attachments = Seq(), sentBy = UserSender(user))
       confirmOutgoingMessage {
         msg =>
           msg.text should include("mock help")
@@ -58,7 +58,7 @@ class HelpTest extends BotPluginTestKit(ActorSystem("HelpTest")) {
     }
 
     "return an error for unknown commands" in {
-      helpRef ! IncomingMessage("help test", true, InstantMessageChannel("125", user), "1527239216000090", UserSender(user), Seq())
+      helpRef ! IncomingMessage("help test", true, InstantMessageChannel("125", user), "1527239216000090", attachments = Seq(), sentBy = UserSender(user))
       confirmOutgoingMessage {
         msg =>
           msg.text should include("Sorry, I don't know")


### PR DESCRIPTION
* We were to failing to read threads earlier because threads message come with thread timeStamp. Added parentTimeStamp as optional to overcome this.
* Other changes are small formatting which I found on the fly

Fix is created by [mridul](https://github.com/mridulv) and it worked very well for us when we were reading threads messages for hackathon project.