### PR TITLE
Fix responding to a message in thread in the same thread

### DIFF
--- a/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
+++ b/src/main/scala/com/sumologic/sumobot/plugins/BotPlugin.scala
@@ -79,7 +79,7 @@ abstract class BotPlugin
   class RichIncomingMessage(msg: IncomingMessage) {
     def response(text: String, inThread: Boolean = false) = {
       val threadTs = if (inThread) {
-        Some(msg.idTimestamp)
+        msg.threadTimestamp.orElse(Some(msg.idTimestamp))
       } else {
         None
       }


### PR DESCRIPTION
When responding to a message in thread, we should set threadTs as the parent ts.