### PR TITLE
Upgrading Play to 2.7.1 for version compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>com.typesafe.play</groupId>
       <artifactId>play-json_2.11</artifactId>
-      <version>2.6.9</version>
+      <version>2.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>


### PR DESCRIPTION
Upgrading Play, otherwise executions fail with:
```
Caused by: java.lang.NoSuchMethodError: play.api.libs.json.JsonConfiguration.optionHandlers()Lplay/api/libs/json/OptionHandlers;
```