### PR TITLE
sumobot-over-HTTP: Initial implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,7 @@
             <exclude>target/**</exclude>
             <exclude>.clover/**</exclude>
             <exclude>src/main/assembly.xml</exclude>
+            <exclude>**/*.html</exclude>
           </excludes>
           <useDefaultExcludes>true</useDefaultExcludes>
           <useDefaultMapping>true</useDefaultMapping>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-stream_${scala.version.major}</artifactId>
+      <version>${akka.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.version.major}</artifactId>
       <version>2.2.5</version>

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/index.html
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Sumobot-over-HTTP</title>
+    <meta name="description" content="Sumobot-over-HTTP">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script type="text/javascript" src="script.js"></script>
+</head>
+<body>
+    <input title="message" id="message" name="message" type="text" />
+    <input type="submit" id="submit" value="Send" />
+    <div id="messages">
+        Messages:
+    </div>
+</body>
+</html>
+        

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/index.html
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/index.html
@@ -1,3 +1,21 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/script.js
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/script.js
@@ -1,0 +1,19 @@
+window.onload = function() {
+    var endpoint = "ws://" + window.location.host + "/websocket";
+
+    var socket = new WebSocket(endpoint);
+    var messageBox = document.getElementById("messages");
+
+    var submitButton = document.getElementById("submit");
+    submitButton.onclick = function() {
+        var messageBox = document.getElementById("message");
+        socket.send(messageBox.value);
+    };
+
+    socket.onmessage = function(event) {
+        var messageItem = document.createElement("p");
+        messageItem.textContent = event.data;
+        messageItem.setAttribute("style", "background: gray; padding: 20px; white-space: pre-line;")
+        messageBox.appendChild(messageItem);
+    };
+};

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/script.js
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/script.js
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 window.onload = function() {
     var endpoint = "ws://" + window.location.host + "/websocket";
 

--- a/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
@@ -21,6 +21,7 @@ package com.sumologic.sumobot.core
 import java.io.File
 
 import akka.actor.{ActorRef, ActorSystem, Props}
+import com.sumologic.sumobot.http_frontend.SumoBotHttpServer
 import com.sumologic.sumobot.plugins.PluginCollection
 import com.typesafe.config.ConfigFactory
 import slack.api.{BlockingSlackApiClient, SlackApiClient}
@@ -39,6 +40,18 @@ object Bootstrap {
 
   def bootstrap(brainProps: Props,
                 pluginCollections: PluginCollection*): Unit = {
+    val frontend = selectedFrontend()
+
+    frontend match {
+      case "slack" =>
+        bootstrapSlack(brainProps, pluginCollections)
+      case "http" =>
+        bootstrapHttp(brainProps, pluginCollections)
+    }
+  }
+
+  private def bootstrapSlack(brainProps: Props,
+                             pluginCollections: Seq[PluginCollection]): Unit = {
     val slackConfig = system.settings.config.getConfig("slack")
     val rtmClient = SlackRtmClient(
       token = slackConfig.getString("api.token"),
@@ -56,6 +69,31 @@ object Bootstrap {
     pluginCollections.par.foreach(_.setup)
 
     sys.addShutdownHook(shutdownActorSystem())
+  }
+
+  private def bootstrapHttp(brainProps: Props, pluginCollections: Seq[PluginCollection]): Unit = {
+    val httpConfig = system.settings.config.getConfig("http")
+    val httpHost = httpConfig.getString("host")
+    val httpPort = httpConfig.getInt("port")
+
+    val brain = system.actorOf(brainProps, "brain")
+    val httpServer = new SumoBotHttpServer(httpHost, httpPort)
+
+    receptionist = Some(system.actorOf(Props(classOf[HttpReceptionist], brain), "receptionist"))
+
+    pluginCollections.par.foreach(_.setup)
+
+    sys.addShutdownHook(shutdownActorSystem())
+  }
+
+  private def selectedFrontend(): String = {
+    val isSlackSelected = system.settings.config.hasPath("slack.api.token")
+    val isHttpSelected = system.settings.config.hasPath("http")
+
+    if (isHttpSelected && isSlackSelected) throw new RuntimeException("Only one frontend can be selected")
+    if (!isHttpSelected && !isSlackSelected) throw new RuntimeException("No frontend selected")
+
+    if (isSlackSelected) "slack" else "http"
   }
 
   private def shutdownActorSystem(): Unit = {

--- a/src/main/scala/com/sumologic/sumobot/core/HttpReceptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/HttpReceptionist.scala
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.sumobot.core
 
 import java.time.Instant

--- a/src/main/scala/com/sumologic/sumobot/core/HttpReceptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/HttpReceptionist.scala
@@ -1,0 +1,44 @@
+package com.sumologic.sumobot.core
+
+import java.time.Instant
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import com.sumologic.sumobot.core.model.PublicChannel
+import com.sumologic.sumobot.plugins.BotPlugin.{InitializePlugin, PluginAdded, PluginRemoved}
+import play.api.libs.json.{JsObject, JsValue}
+import slack.api.RtmStartState
+import slack.models.{Channel, Group, Im, Team, User}
+import slack.rtm.RtmState
+
+object HttpReceptionist {
+  private[core] val DefaultChannel = Channel("C0001SUMO", "sumobot", Instant.now().getEpochSecond(),
+    Some("U0001SUMO"), Some(false), Some(true), Some(false), Some(true), None, Some(false), None, None, None, None, None, None, None, None)
+  val DefaultSumoBotChannel = PublicChannel(DefaultChannel.id, DefaultChannel.name)
+
+  val DefaultBotUser = User("U0001SUMO", "sumobot-bot", None, None, None, None, None, None, None, None, None, None, None, None, None, None)
+  val DefaultClientUser = User("U0002SUMO", "sumobot-client", None, None, None, None, None, None, None, None, None, None, None, None, None, None)
+
+  private[core] val StateUrl = ""
+  private[core] val StateTeam = Team("T0001SUMO", "Sumo Bot", "sumobot", "sumologic.com", 30, false, new JsObject(Map.empty), "std")
+  private[core] val StateUsers: Seq[User] = Array(DefaultBotUser, DefaultClientUser)
+  private[core] val StateChannels: Seq[Channel] = Array(DefaultChannel)
+  private[core] val StateGroups: Seq[Group] = Seq.empty
+  private[core] val StateIms: Seq[Im] = Seq.empty
+  private[core] val StateBots: Seq[JsValue] = Seq.empty
+
+  private[core] val StartState = RtmStartState(StateUrl, DefaultBotUser, StateTeam, StateUsers, StateChannels, StateGroups, StateIms, StateBots)
+  private[core] val State = new RtmState(StartState)
+}
+
+class HttpReceptionist(brain: ActorRef) extends Actor with ActorLogging {
+  private val pluginRegistry = context.system.actorOf(Props(classOf[PluginRegistry]), "plugin-registry")
+
+  override def receive: Receive = {
+    case message@PluginAdded(plugin, _) =>
+      plugin ! InitializePlugin(HttpReceptionist.State, brain, pluginRegistry)
+      pluginRegistry ! message
+
+    case message@PluginRemoved(_) =>
+      pluginRegistry ! message
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/HttpIncomingReceiver.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/HttpIncomingReceiver.scala
@@ -1,0 +1,39 @@
+package com.sumologic.sumobot.http_frontend
+
+import java.time.Instant
+
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import akka.http.javadsl.model.ws.TextMessage
+import akka.stream.ActorMaterializer
+import com.sumologic.sumobot.core.HttpReceptionist
+import com.sumologic.sumobot.core.model.{IncomingMessage, UserSender}
+
+object HttpIncomingReceiver {
+  case class StreamEnded()
+}
+
+class HttpIncomingReceiver(outcomingRef: ActorRef) extends Actor with ActorLogging {
+  private val StrictTimeout = 10000
+
+  private val materializer = ActorMaterializer()
+
+  override def receive: Receive = {
+    case msg: TextMessage =>
+      val contents = messageContents(msg).trim
+      val incomingMessage = IncomingMessage(contents, true, HttpReceptionist.DefaultSumoBotChannel,
+        formatDateNow(), None, Seq.empty, UserSender(HttpReceptionist.DefaultClientUser))
+      context.system.eventStream.publish(incomingMessage)
+
+    case HttpIncomingReceiver.StreamEnded =>
+      context.stop(outcomingRef)
+      context.stop(self)
+  }
+
+  private def messageContents(msg: TextMessage): String = {
+    msg.toStrict(StrictTimeout, materializer).toCompletableFuture.get().getStrictText
+  }
+
+  private def formatDateNow(): String = {
+    s"${Instant.now().getEpochSecond}.000000"
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/HttpIncomingReceiver.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/HttpIncomingReceiver.scala
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.sumobot.http_frontend
 
 import java.time.Instant

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/HttpOutcomingSender.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/HttpOutcomingSender.scala
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.sumobot.http_frontend
 
 import akka.actor.{Actor, ActorLogging, ActorRef}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/HttpOutcomingSender.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/HttpOutcomingSender.scala
@@ -1,0 +1,21 @@
+package com.sumologic.sumobot.http_frontend
+
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import akka.http.scaladsl.model.ws.TextMessage
+import com.sumologic.sumobot.core.model.OutgoingMessage
+
+class HttpOutcomingSender(publisherRef: ActorRef) extends Actor with ActorLogging {
+  override def preStart(): Unit = {
+    Seq(classOf[OutgoingMessage]).foreach(context.system.eventStream.subscribe(self, _))
+  }
+
+  override def receive: Receive = {
+    case OutgoingMessage(_, text, _) =>
+      publisherRef ! TextMessage(text)
+  }
+
+  override def postStop(): Unit = {
+    context.stop(publisherRef)
+    context.system.eventStream.unsubscribe(self)
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/StaticResource.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/StaticResource.scala
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.sumobot.http_frontend
 
 import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpCharsets, MediaTypes}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/StaticResource.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/StaticResource.scala
@@ -1,0 +1,25 @@
+package com.sumologic.sumobot.http_frontend
+
+import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpCharsets, MediaTypes}
+import org.apache.commons.io.IOUtils
+
+object StaticResource {
+  private[http_frontend] val DefaultContentType = ContentTypes.`text/html(UTF-8)`
+
+  private[http_frontend] val KnownContentTypes = Array(
+    (".html", ContentTypes.`text/html(UTF-8)`),
+    (".css", ContentType(MediaTypes.`text/css`, HttpCharsets.`UTF-8`)),
+    (".js", ContentType(MediaTypes.`application/javascript`, HttpCharsets.`UTF-8`)))
+}
+
+case class StaticResource(filename: String) {
+  private val stream = getClass.getResourceAsStream(filename)
+
+  val contents: Array[Byte] = IOUtils.toByteArray(stream)
+  stream.close()
+
+  def contentType: ContentType = {
+    val contentType = StaticResource.KnownContentTypes.find(contentType => filename.endsWith(contentType._1)).map(_._2)
+    contentType.getOrElse(StaticResource.DefaultContentType)
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.sumobot.http_frontend
 
 import akka.actor.{ActorRef, ActorSystem, Props}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
@@ -1,0 +1,77 @@
+package com.sumologic.sumobot.http_frontend
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods.GET
+import akka.http.scaladsl.model.ws.{Message, UpgradeToWebSocket}
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, Uri}
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.{ActorMaterializer, Materializer, OverflowStrategy}
+import org.reactivestreams.Publisher
+
+object SumoBotHttpServer {
+  private[http_frontend] val UrlSeparator = "/"
+
+  private[http_frontend] val RootPage = "index.html"
+  private[http_frontend] val WebSocketEndpoint = UrlSeparator + "websocket"
+
+  private[http_frontend] val Resources = Set(UrlSeparator + RootPage, UrlSeparator + "script.js")
+
+  private[http_frontend] val BufferSize = 128
+  private[http_frontend] val SocketOverflowStrategy = OverflowStrategy.fail
+}
+
+class SumoBotHttpServer(httpHost: String, httpPort: Int)(implicit system: ActorSystem) {
+  import SumoBotHttpServer._
+
+  private implicit val materializer: Materializer = ActorMaterializer()
+
+  private val serverSource = Http().bind(httpHost, httpPort)
+
+  private val requestHandler: HttpRequest => HttpResponse = {
+    case HttpRequest(GET, Uri.Path("/"), _, _, _) =>
+      staticResource(RootPage)
+
+    case req@HttpRequest(GET, Uri.Path(WebSocketEndpoint), _, _, _) =>
+      webSocketRequestHandler(req)
+
+    case HttpRequest(GET, Uri.Path(path), _, _, _)
+      if Resources.contains(path) =>
+      val filename = path.replaceFirst(UrlSeparator, "")
+      staticResource(filename)
+
+    case invalid: HttpRequest =>
+      invalid.discardEntityBytes()
+      HttpResponse(403)
+  }
+
+  private def staticResource(filename: String): HttpResponse = {
+    val resource = StaticResource(filename)
+    HttpResponse(entity = HttpEntity(resource.contentType, resource.contents))
+  }
+
+  private def webSocketRequestHandler(req: HttpRequest): HttpResponse = {
+    req.header[UpgradeToWebSocket] match {
+      case Some(upgrade) =>
+        webSocketUpgradeHandler(upgrade)
+      case None => HttpResponse(400, entity = "Invalid WebSocket request")
+    }
+  }
+
+  def webSocketUpgradeHandler(upgrade: UpgradeToWebSocket): HttpResponse = {
+    val (publisherRef: ActorRef, publisher: Publisher[Message]) =
+      Source.actorRef[Message](BufferSize, SocketOverflowStrategy)
+      .toMat(Sink.asPublisher(true))(Keep.both).run()
+
+    val publisherSource = Source.fromPublisher(publisher)
+
+    val senderRef = system.actorOf(Props(classOf[HttpOutcomingSender], publisherRef))
+    val receiverRef = system.actorOf(Props(classOf[HttpIncomingReceiver], senderRef))
+
+    val sink = Sink.actorRef(receiverRef, HttpIncomingReceiver.StreamEnded)
+
+    upgrade.handleMessagesWithSinkSource(sink, publisherSource)
+  }
+
+  serverSource.to(Sink.foreach(_.handleWithSyncHandler(requestHandler))).run()
+}


### PR DESCRIPTION
sumobot-over-HTTP is a new sumobot feature, which allows you to run and test sumobot without Slack: instead visiting a website served by local HTTP server. You can send messages to sumobot and receive its replies in real time.

##### Starting server
In order to start a local HTTP server, you need to add following lines to your `sumobot.conf`:
```
http {
  host = "0.0.0.0"
  port = 8080
}
```
and delete `slack` entires (`api.token`). After launching with `mvn compile exec:java -Dexec.mainClass="com.sumologic.sumobot.Main"` you can visit `http://localhost:8080` and interact with bot.

##### Known limitations
- No unit tests (will add after changing from draft PR to normal PR).
- All communication done on a single "channel" - everyone connected is treated as a single user.
- "Placeholder" UI - no CSS, layout (coming in next PR). Placeholder `setAttribute("style")`.
- Connection timeout after ~1 minute (need to add entry to Akka config).
- Akka warnings/dead letter messages.
- Only a subset of sumobot messages implemented (no messages with attachments).