### PR TITLE
sumobot-over-HTTP: Authentication system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ http {
 
 After starting Sumo Bot, you can visit started server at `http://localhost:8080/`.
 
-To run server exposed to external world, change `host` to `0.0.0.0`.
+To run server exposed to external world, change `host` to `0.0.0.0`. For advanced configuration options, see: [`config/sumobot.conf.example`](https://github.com/SumoLogic/sumobot/blob/master/config/sumobot.conf.example).
 
 ### [Dev] How to release new version
 1. Make sure you have all credentials.

--- a/config/sumobot.conf.example
+++ b/config/sumobot.conf.example
@@ -44,6 +44,8 @@ http {
   #   enabled = true
   #   class = "com.sumologic.sumobot.http_frontend.authentication.AlbJwtAuthentication"
   #   key-endpoint = "..."
+  #   cookie-name = "..."
+  #   logout-redirect = "..."
   # }
 
   # UI customization (shown in top bar):

--- a/config/sumobot.conf.example
+++ b/config/sumobot.conf.example
@@ -1,7 +1,13 @@
 # Only one frontend (slack, http) can be active at the same time.
 
 slack {
+  # Required parameters:
   api.token = "..."
+
+  # Optional parameters:
+
+  # (default true, when slack API token defined)
+  # enabled = true
 }
 
 http {
@@ -11,18 +17,45 @@ http {
 
   # Optional parameters:
 
+  # (default true, when http block defined)
+  # enabled = true
+
   # Origin (Access-Control-Allow-Origin header, default: *):
   # origin = "..."
 
-  # Authentication (at most one active at the same time):
+  # Authentication:
 
   # No authentication (default)
-  # no-authentication {}
+  # authentication {
+  #   enabled = true
+  #   class = "com.sumologic.sumobot.http_frontend.authentication.NoAuthentication"
+  # }
 
   # HTTP Basic Authentication
-  # basic-authentication {
+  # authentication {
+  #   enabled = true
+  #   class = "com.sumologic.sumobot.http_frontend.authentication.BasicAuthentication"
   #   username = "..."
   #   password = "..."
+  # }
+
+  # AWS ALB Authentication
+  # authentication {
+  #   enabled = true
+  #   class = "com.sumologic.sumobot.http_frontend.authentication.AlbJwtAuthentication"
+  #   key-endpoint = "..."
+  # }
+
+  # UI customization (shown in top bar):
+
+  # title = "..."
+  # description = "..."
+  # links {
+  #   mylink1 {
+  #     name = "..."
+  #     href = "..."
+  #   }
+  #   ...
   # }
 }
 

--- a/config/sumobot.conf.example
+++ b/config/sumobot.conf.example
@@ -1,12 +1,29 @@
-# only one frontend (slack, http) can be active at the same time
+# Only one frontend (slack, http) can be active at the same time.
 
 slack {
   api.token = "..."
 }
 
 http {
+  # Required parameters:
   host = "localhost"
   port = 8080
+
+  # Optional parameters:
+
+  # Origin (Access-Control-Allow-Origin header, default: *):
+  # origin = "..."
+
+  # Authentication (at most one active at the same time):
+
+  # No authentication (default)
+  # no-authentication {}
+
+  # HTTP Basic Authentication
+  # basic-authentication {
+  #   username = "..."
+  #   password = "..."
+  # }
 }
 
 # Not read by the code, just used in the config.

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
             <exclude>.clover/**</exclude>
             <exclude>src/main/assembly.xml</exclude>
             <exclude>**/*.html</exclude>
+            <exclude>**/*.css</exclude>
           </excludes>
           <useDefaultExcludes>true</useDefaultExcludes>
           <useDefaultMapping>true</useDefaultMapping>

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,11 @@
       <version>2.7.1</version>
     </dependency>
     <dependency>
+      <groupId>com.pauldijou</groupId>
+      <artifactId>jwt-play-json_2.11</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-http_2.11</artifactId>
       <version>10.0.11</version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.scalatra.scalate</groupId>
+      <artifactId>scalate-core_2.11</artifactId>
+      <version>1.9.4</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.12</version>
@@ -278,7 +284,7 @@
             <exclude>target/**</exclude>
             <exclude>.clover/**</exclude>
             <exclude>src/main/assembly.xml</exclude>
-            <exclude>**/*.html</exclude>
+            <exclude>**/*.ssp</exclude>
             <exclude>**/*.css</exclude>
           </excludes>
           <useDefaultExcludes>true</useDefaultExcludes>

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/index.html
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/index.html
@@ -24,12 +24,16 @@
     <meta name="description" content="Sumobot-over-HTTP">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script type="text/javascript" src="script.js"></script>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
 </head>
 <body>
-    <input title="message" id="message" name="message" type="text" />
-    <input type="submit" id="submit" value="Send" />
-    <div id="messages">
-        Messages:
+    <div class="page-container">
+        <div id="messages"></div>
+        <div class="inputs">
+            <input title="message" id="message-input" type="text" />
+            <input type="submit" id="submit" value="Send" />
+        </div>
     </div>
 </body>
 </html>

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/index.ssp
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/index.ssp
@@ -16,13 +16,16 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<%@ var authMessage:Option[String] %>
+#import(com.sumologic.sumobot.http_frontend.authentication.AuthenticationInfo)
+#import(com.sumologic.sumobot.http_frontend.SumoBotHttpServerOptions)
+<%@ var authInfo: AuthenticationInfo %>
+<%@ var serverOptions: SumoBotHttpServerOptions %>
 
 <!doctype html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Sumobot-over-HTTP</title>
+    <title>${serverOptions.title}</title>
     <meta name="description" content="Sumobot-over-HTTP">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script type="text/javascript" src="script.js"></script>
@@ -32,7 +35,19 @@
 <body>
     <div class="page-container">
         <div class="header">
-            <h1>Sumobot-over-HTTP</h1> <p>${authMessage.getOrElse("")}</p>
+            <h1>${serverOptions.title}</h1>
+            #if (serverOptions.description.isDefined)
+                <span>${serverOptions.description.get}</span>
+            #end
+            #for (link <- serverOptions.links)
+                <span><a href="${link.href}">${link.name}</a></span>
+            #end
+            #if (authInfo.authMessage.isDefined)
+                <span>${authInfo.authMessage.get}</span>
+            #end
+            #for (link <- authInfo.authLinks)
+                <span><a href="${link.href}">${link.name}</a></span>
+            #end
         </div>
         <div id="messages" class="messages"></div>
         <form class="inputs">

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/index.ssp
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/index.ssp
@@ -32,7 +32,7 @@
 <body>
     <div class="page-container">
         <div class="header">
-            <h1>Sumobot-over-HTTP</h1> <p>${authMessage.get}</p>
+            <h1>Sumobot-over-HTTP</h1> <p>${authMessage.getOrElse("")}</p>
         </div>
         <div id="messages" class="messages"></div>
         <form class="inputs">

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/index.ssp
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/index.ssp
@@ -16,6 +16,8 @@
     specific language governing permissions and limitations
     under the License.
 -->
+<%@ var authMessage:Option[String] %>
+
 <!doctype html>
 <html lang="en">
 <head>
@@ -25,10 +27,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script type="text/javascript" src="script.js"></script>
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" rel="stylesheet">
 </head>
 <body>
     <div class="page-container">
+        <div class="header">
+           <h1>Sumobot-over-HTTP</h1> <p>${authMessage.get}</p>
+        </div>
         <div id="messages"></div>
         <div class="inputs">
             <input title="message" id="message-input" type="text" />
@@ -37,4 +42,3 @@
     </div>
 </body>
 </html>
-        

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/script.js
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/script.js
@@ -18,23 +18,39 @@
  */
 window.onload = function() {
     var websocketProtocol = window.location.protocol === "https:" ? "wss://" : "ws://";
-
     var endpoint = websocketProtocol + window.location.host + window.location.pathname + "websocket";
-
     var socket = new WebSocket(endpoint);
-    var messageBox = document.getElementById("messages");
 
+    var messageBox = document.getElementById("messages");
+    var messageInput = document.getElementById("message-input");
     var submitButton = document.getElementById("submit");
+
+    function appendMessage(msg, styles) {
+        var messageItem = document.createElement("div");
+        messageItem.textContent = msg;
+        messageItem.setAttribute("class", styles);
+        messageBox.appendChild(messageItem);
+        messageItem.scrollIntoView({block: "end", inline: "nearest", behavior: "smooth"});
+    }
+
+    function sendMessage() {
+        socket.send(messageInput.value);
+        appendMessage(messageInput.value, "message outcoming");
+        messageInput.value = "";
+    }
+
     submitButton.onclick = function() {
-        var messageBox = document.getElementById("message");
-        socket.send(messageBox.value);
+        sendMessage();
     };
 
+    messageInput.onkeydown = function(event) {
+        if (event.key === 'Enter') {
+            sendMessage();
+        }
+    }
+
     socket.onmessage = function(event) {
-        var messageItem = document.createElement("p");
-        messageItem.textContent = event.data;
-        messageItem.setAttribute("style", "background: gray; padding: 20px; white-space: pre-line;");
-        messageBox.appendChild(messageItem);
+        appendMessage(event.data, "message incoming");
     };
 
     window.onbeforeunload = function() {

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/style.css
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/style.css
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ html, body {
+    height: 100%;
+
+    padding: 0;
+    margin: 0;
+
+    background-color: #f7f7f7;
+ }
+
+ body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    font-family: 'Open Sans', sans-serif;
+ }
+
+ .page-container {
+    padding: 10px;
+
+    background-color: white;
+
+    box-shadow: 0px 0px 60px #d4d4d4;
+
+    border-radius: 20px;
+ }
+
+ #messages {
+    display: flex;
+    flex-direction: column;
+
+    width: 500px;
+    height: 500px;
+
+    padding: 10px;
+
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    margin: auto;
+ }
+
+.message {
+    white-space: pre-line;
+
+    font-size: 11pt;
+
+    min-width: 100px;
+    max-width: 200px;
+
+    padding: 12px;
+
+    margin-bottom: 10px;
+
+    animation-name: new-message;
+    animation-duration: 0.15s;
+    animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.incoming {
+    background-color: #5780f6;
+    color: white;
+
+    border-radius: 20px 20px 20px 2px;
+
+    align-self: flex-start;
+}
+
+.outcoming {
+    background-color: #ecf0fe;
+    color: #85a2fa;
+
+    border: 1px solid #e1e8ed;
+    border-radius: 20px 20px 2px 20px;
+
+    align-self: flex-end;
+}
+
+@keyframes new-message {
+    from { transform: scale(1.2); opacity: 0.5; }
+    to { transform: scale(1.0); opacity: 1.0; }
+}
+
+.inputs {
+    display: flex;
+    justify-content: space-around;
+    padding: 15px 5px 5px 5px;
+}
+
+#message-input {
+    width: 80%;
+    padding: 4px 8px 4px 8px;
+
+    outline: none;
+    height: 30px;
+
+    font-size: 11pt;
+
+    border: 1px solid #e1e8ed;
+    border-radius: 15px;
+}
+
+#message-input:focus {
+    background-color: #fafbff;
+    border: 1px solid #bfccff;
+}
+
+#submit {
+    border: none;
+    border-radius: 15px;
+
+    width: 60px;
+    height: 40px;
+
+    outline: none;
+
+    font-size: 11pt;
+
+    background-color: #5780f6;
+    color: white;
+}

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/style.css
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/style.css
@@ -126,6 +126,7 @@ body {
     height: 40px;
     outline: none;
     font-size: 0.95rem;
+    font-weight: 700;
     background-color: #5780f6;
     color: white;
 }

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/style.css
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/style.css
@@ -43,16 +43,26 @@ body {
 }
 
 .header h1 {
-    font-size: 15pt;
+    font-size: 1.25rem;
     font-weight: 700;
     margin: 0 0 5px 0;
 }
 
-.header p {
-    display: inline;
+.header span {
+    display: inline-block;
     text-transform: uppercase;
-    font-size: 9pt;
-    color: #555;
+    font-size: 0.75rem;
+    color: #777;
+}
+
+.header span:not(:last-child) {
+    padding-right: 9px;
+    margin-right: 5px;
+    border-right: 1px solid #777;
+}
+
+.header a {
+    color: #777;
 }
 
 .messages {
@@ -68,10 +78,10 @@ body {
 
 .message {
     white-space: pre-line;
-    font-size: 0.95rem;
-    min-width: 100px;
+    font-size: 0.9rem;
+    min-width: 70px;
     max-width: 200px;
-    padding: 12px;
+    padding: 10px;
     margin-bottom: 10px;
     animation-name: new-message;
     animation-duration: 0.15s;
@@ -106,10 +116,10 @@ body {
 
 .message-input {
     width: 80%;
-    padding: 4px 8px 4px 8px;
+    padding: 2px 8px 2px 8px;
     outline: none;
     height: 30px;
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     border: 1px solid #e1e8ed;
     border-radius: 15px;
 }
@@ -123,9 +133,9 @@ body {
     border: none;
     border-radius: 15px;
     width: 60px;
-    height: 40px;
+    height: 34px;
     outline: none;
-    font-size: 0.95rem;
+    font-size: 0.90rem;
     font-weight: 700;
     background-color: #5780f6;
     color: white;

--- a/src/main/resources/com/sumologic/sumobot/http_frontend/style.css
+++ b/src/main/resources/com/sumologic/sumobot/http_frontend/style.css
@@ -16,24 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
- html, body {
+html, body {
     height: 100%;
 
     padding: 0;
     margin: 0;
 
     background-color: #f7f7f7;
- }
+}
 
- body {
+body {
     display: flex;
     justify-content: center;
     align-items: center;
 
     font-family: 'Open Sans', sans-serif;
- }
+}
 
- .page-container {
+.page-container {
     padding: 10px;
 
     background-color: white;
@@ -41,9 +41,30 @@
     box-shadow: 0px 0px 60px #d4d4d4;
 
     border-radius: 20px;
- }
+}
 
- #messages {
+.header {
+    border-bottom: 1px solid #e1e8ed;
+    padding: 7px 7px 10px 7px;
+}
+
+.header h1 {
+    font-size: 15pt;
+    font-weight: 700;
+
+    margin: 0 0 5px 0;
+}
+
+.header p {
+    display: inline;
+
+    text-transform: uppercase;
+
+    font-size: 9pt;
+    color: #555;
+}
+
+#messages {
     display: flex;
     flex-direction: column;
 
@@ -56,7 +77,7 @@
     overflow-y: auto;
 
     margin: auto;
- }
+}
 
 .message {
     white-space: pre-line;

--- a/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
@@ -78,9 +78,12 @@ object Bootstrap {
     val httpConfig = system.settings.config.getConfig("http")
     val httpHost = httpConfig.getString("host")
     val httpPort = httpConfig.getInt("port")
+    val origin = if (httpConfig.hasPath("origin")) {
+      httpConfig.getString("origin")
+    } else SumoBotHttpServer.DefaultOrigin
 
     val brain = system.actorOf(brainProps, "brain")
-    val httpServer = new SumoBotHttpServer(httpHost, httpPort)
+    val httpServer = new SumoBotHttpServer(httpHost, httpPort, origin)
 
     receptionist = Some(system.actorOf(Props(classOf[HttpReceptionist], brain), "receptionist"))
 

--- a/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
@@ -91,13 +91,19 @@ object Bootstrap {
   }
 
   private def selectedFrontend(): SumobotFrontend = {
-    val isSlackSelected = system.settings.config.hasPath("slack.api.token")
-    val isHttpSelected = system.settings.config.hasPath("http")
+    val isSlackSelected =
+      system.settings.config.hasPath("slack.api.token") && isFrontendEnabled("slack")
+    val isHttpSelected = system.settings.config.hasPath("http") && isFrontendEnabled("http")
 
     if (isHttpSelected && isSlackSelected) throw new IllegalArgumentException("Only one frontend can be selected")
     if (!isHttpSelected && !isSlackSelected) throw new IllegalArgumentException("No frontend selected")
 
     if (isSlackSelected) SlackFrontend else HttpFrontend
+  }
+
+  private def isFrontendEnabled(frontendName: String): Boolean = {
+    !system.settings.config.hasPath(s"$frontendName.enabled") ||
+      system.settings.config.getBoolean(s"$frontendName.enabled")
   }
 
   private def shutdownActorSystem(): Unit = {

--- a/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
@@ -77,14 +77,9 @@ object Bootstrap {
 
   private def bootstrapHttp(brainProps: Props, pluginCollections: Seq[PluginCollection]): Unit = {
     val httpConfig = system.settings.config.getConfig("http")
-    val httpHost = httpConfig.getString("host")
-    val httpPort = httpConfig.getInt("port")
-    val origin = if (httpConfig.hasPath("origin")) {
-      httpConfig.getString("origin")
-    } else SumoBotHttpServer.DefaultOrigin
 
     val brain = system.actorOf(brainProps, "brain")
-    val httpServerOptions = SumoBotHttpServerOptions(httpHost, httpPort, origin, new NoAuthentication())
+    val httpServerOptions = SumoBotHttpServerOptions.fromConfig(httpConfig)
     val httpServer = new SumoBotHttpServer(httpServerOptions)
 
     receptionist = Some(system.actorOf(Props(classOf[HttpReceptionist], brain), "receptionist"))

--- a/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
@@ -21,7 +21,8 @@ package com.sumologic.sumobot.core
 import java.io.File
 
 import akka.actor.{ActorRef, ActorSystem, Props}
-import com.sumologic.sumobot.http_frontend.SumoBotHttpServer
+import com.sumologic.sumobot.http_frontend.authentication.{BasicAuthentication, NoAuthentication}
+import com.sumologic.sumobot.http_frontend.{SumoBotHttpServer, SumoBotHttpServerOptions}
 import com.sumologic.sumobot.plugins.PluginCollection
 import com.typesafe.config.ConfigFactory
 import slack.api.{BlockingSlackApiClient, SlackApiClient}
@@ -83,7 +84,8 @@ object Bootstrap {
     } else SumoBotHttpServer.DefaultOrigin
 
     val brain = system.actorOf(brainProps, "brain")
-    val httpServer = new SumoBotHttpServer(httpHost, httpPort, origin)
+    val httpServerOptions = SumoBotHttpServerOptions(httpHost, httpPort, origin, new NoAuthentication())
+    val httpServer = new SumoBotHttpServer(httpServerOptions)
 
     receptionist = Some(system.actorOf(Props(classOf[HttpReceptionist], brain), "receptionist"))
 

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/RoutingHelper.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/RoutingHelper.scala
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend
+
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, ResponseEntity}
+import akka.http.scaladsl.model.HttpMethods.{GET, HEAD}
+import akka.stream.Materializer
+
+case class RoutingHelper(origin: String)(implicit materializer: Materializer) {
+  def withAllowOriginHeader(routing: PartialFunction[HttpRequest, HttpResponse]): PartialFunction[HttpRequest, HttpResponse] = {
+    routing.andThen {
+      response: HttpResponse =>
+        val oldHeaders = response.headers.filter(header => header.isNot(`Access-Control-Allow-Origin`.lowercaseName)).toList
+        val newHeaders = oldHeaders :+ `Access-Control-Allow-Origin`(origin)
+
+        response.withHeaders(newHeaders)
+    }
+  }
+
+  def withHeadRequests(routing: PartialFunction[HttpRequest, HttpResponse]): PartialFunction[HttpRequest, HttpResponse] = {
+    routing.orElse {
+      case request@HttpRequest(HEAD, _, _, _, _)
+        if routing.isDefinedAt(request.withMethod(GET)) =>
+        val response = routing(request.withMethod(GET))
+
+        val oldEntity = response.entity
+        val newEntity = HttpEntity(oldEntity.contentType, Array.empty[Byte])
+
+        response.withEntity(newEntity)
+    }
+  }
+
+  def withForbiddenFallback(routing: PartialFunction[HttpRequest, HttpResponse]): PartialFunction[HttpRequest, HttpResponse] = {
+    routing.orElse {
+      case invalid: HttpRequest =>
+        invalid.discardEntityBytes()
+        HttpResponse(403)
+    }
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/RoutingHelper.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/RoutingHelper.scala
@@ -28,7 +28,10 @@ case class RoutingHelper(origin: String)(implicit materializer: Materializer) {
     routing.andThen {
       response: HttpResponse =>
         val oldHeaders = response.headers.filter(header => header.isNot(`Access-Control-Allow-Origin`.lowercaseName)).toList
-        val newHeaders = oldHeaders :+ `Access-Control-Allow-Origin`(origin)
+        val accessOrigin = if (origin == "*") {
+          `Access-Control-Allow-Origin`.*
+        } else `Access-Control-Allow-Origin`(origin)
+        val newHeaders = oldHeaders :+ accessOrigin
 
         response.withHeaders(newHeaders)
     }

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
@@ -27,7 +27,7 @@ import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, Uri}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer, OverflowStrategy}
 import com.sumologic.sumobot.http_frontend.SumoBotHttpServer._
-import com.sumologic.sumobot.http_frontend.authentication.{AuthenticationForbidden, AuthenticationInfo, AuthenticationSucceeded, HttpAuthentication}
+import com.sumologic.sumobot.http_frontend.authentication.{AuthenticationForbidden, AuthenticationInfo, AuthenticationSucceeded, NoAuthentication}
 import org.reactivestreams.Publisher
 
 import scala.concurrent.Await
@@ -35,6 +35,7 @@ import scala.concurrent.duration._
 
 object SumoBotHttpServer {
   val DefaultOrigin = "*"
+  val DefaultAuthentication = new NoAuthentication()
 
   private[http_frontend] val UrlSeparator = "/"
 
@@ -46,8 +47,6 @@ object SumoBotHttpServer {
   private[http_frontend] val BufferSize = 128
   private[http_frontend] val SocketOverflowStrategy = OverflowStrategy.fail
 }
-
-case class SumoBotHttpServerOptions(httpHost: String, httpPort: Int, origin: String, authentication: HttpAuthentication)
 
 class SumoBotHttpServer(options: SumoBotHttpServerOptions)(implicit system: ActorSystem) {
   private implicit val materializer: Materializer = ActorMaterializer()

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
@@ -38,7 +38,8 @@ object SumoBotHttpServer {
   private[http_frontend] val RootPage = "index.html"
   private[http_frontend] val WebSocketEndpoint = UrlSeparator + "websocket"
 
-  private[http_frontend] val Resources = Set(UrlSeparator + RootPage, UrlSeparator + "script.js")
+  private[http_frontend] val Resources = Set(
+    UrlSeparator + RootPage, UrlSeparator + "script.js", UrlSeparator + "style.css")
 
   private[http_frontend] val BufferSize = 128
   private[http_frontend] val SocketOverflowStrategy = OverflowStrategy.fail

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
@@ -57,13 +57,15 @@ class SumoBotHttpServer(options: SumoBotHttpServerOptions)(implicit system: Acto
   private val serverSource = Http().bind(options.httpHost, options.httpPort)
 
   private val binding = serverSource.to(Sink.foreach(_.handleWithSyncHandler(
-    routingHelper.withAllowOriginHeader(
-      routingHelper.withForbiddenFallback(
-        routingHelper.withHeadRequests(
-          requestHandler
-        )
-      )
-    )
+    routingHelper.withAllowOriginHeader {
+      routingHelper.withForbiddenFallback {
+        options.authentication.routes.orElse {
+          routingHelper.withHeadRequests {
+            requestHandler
+          }
+        }
+      }
+    }
   ))).run()
 
   def terminate(): Unit = {

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerOptions.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerOptions.scala
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend
+
+import com.sumologic.sumobot.http_frontend.authentication.{BasicAuthentication, HttpAuthentication, NoAuthentication}
+import com.typesafe.config.Config
+
+case class SumoBotHttpServerOptions(httpHost: String, httpPort: Int,
+                                    origin: String, authentication: HttpAuthentication)
+
+sealed trait AuthenticationConfig {
+  def configKey: String
+}
+
+case object NoAuthenticationConfig extends AuthenticationConfig {
+  override val configKey: String = "no-authentication"
+}
+
+case object BasicAuthenticationConfig extends AuthenticationConfig {
+  override val configKey: String = "basic-authentication"
+}
+
+object SumoBotHttpServerOptions {
+  private val AuthenticationConfigs = Array(NoAuthenticationConfig, BasicAuthenticationConfig)
+
+  def fromConfig(config: Config): SumoBotHttpServerOptions = {
+    val httpHost = config.getString("host")
+    val httpPort = config.getInt("port")
+    val origin = if (config.hasPath("origin")) {
+      config.getString("origin")
+    } else SumoBotHttpServer.DefaultOrigin
+
+    val authentication = authenticationFromConfig(config)
+
+    SumoBotHttpServerOptions(httpHost, httpPort, origin, authentication)
+  }
+
+  private def authenticationFromConfig(config: Config): HttpAuthentication = {
+    selectedAuthentication(config) match {
+      case Some(NoAuthenticationConfig) =>
+        new NoAuthentication()
+
+      case Some(BasicAuthenticationConfig) =>
+        val username = config.getString(s"${BasicAuthenticationConfig.configKey}.username")
+        val password = config.getString(s"${BasicAuthenticationConfig.configKey}.password")
+
+        new BasicAuthentication(username, password)
+
+      case None =>
+        SumoBotHttpServer.DefaultAuthentication
+    }
+  }
+
+  private def selectedAuthentication(config: Config): Option[AuthenticationConfig] = {
+    val selectedAuthConfigs = AuthenticationConfigs.filter(authConfig => config.hasPath(authConfig.configKey))
+
+    if (selectedAuthConfigs.length > 1) throw new IllegalArgumentException("Only one authentication method can be selected")
+
+    selectedAuthConfigs.headOption
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/AlbJwtAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/AlbJwtAuthentication.scala
@@ -90,11 +90,12 @@ class AlbJwtAuthentication(config: Config) extends HttpAuthentication {
             if (JwtJson.isValid(jwtString, publicKey, Seq(JwtAlgorithm.ES256))) {
               val parsedClaim = Json.parse(claim.content)
               val nameOption = (parsedClaim \\ "name").headOption
+              val emailOption = (parsedClaim \\ "email").headOption.map(email => email.as[String])
               nameOption match {
                 case Some(name) =>
                   val authMessage = Some(s"Logged in as: ${name.as[String]}")
                   val links = Seq(Link("Log out", LogoutEndpointLink))
-                  AuthenticationSucceeded(AuthenticationInfo(authMessage, links))
+                  AuthenticationSucceeded(AuthenticationInfo(authMessage, emailOption, links))
                 case None => FailureResponse
               }
             } else {

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/AlbJwtAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/AlbJwtAuthentication.scala
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend.authentication
+
+import java.security.spec.X509EncodedKeySpec
+import java.security.{KeyFactory, PublicKey}
+import java.util.Base64
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import com.sumologic.sumobot.http_frontend.authentication.AlbJwtAuthentication._
+import com.typesafe.config.Config
+import pdi.jwt.{JwtAlgorithm, JwtHeader, JwtJson, JwtOptions}
+import play.api.libs.json.Json
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.Success
+
+object AlbJwtAuthentication {
+  private val HeaderName = "x-amzn-oidc-data"
+  private val FailureResponse = AuthenticationForbidden(HttpResponse(401))
+  private val KeyEndpointTimeout = 5.seconds
+
+  private val KeyHeaderBegin = "-----BEGIN PUBLIC KEY-----"
+  private val KeyHeaderEnd = "-----END PUBLIC KEY-----"
+}
+
+class AlbJwtAuthentication(config: Config) extends HttpAuthentication {
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+
+  private val keyEndpoint = config.getString("key-endpoint")
+
+  override def authentication(request: HttpRequest): AuthenticationResult = {
+    request.headers.find(header => header.is(HeaderName)) match {
+      case Some(header) => parseJwtString(header.value())
+      case _ => FailureResponse
+    }
+  }
+
+  private def parseJwtString(jwtString: String): AuthenticationResult = {
+    JwtJson.decodeAll(jwtString, JwtOptions(signature = false)) match {
+      case Success((header, claim, _)) =>
+        val key = downloadKey(header)
+        if (key.isEmpty) return FailureResponse
+        val publicKey = parseKey(key.get)
+
+        if (JwtJson.isValid(jwtString, publicKey, Seq(JwtAlgorithm.ES256))) {
+          val parsedClaim = Json.parse(claim.content)
+          val name = (parsedClaim \\ "name").head.as[String]
+          val authInfo = AuthenticationInfo(Some(s"Logged in as: $name"), Seq.empty)
+          AuthenticationSucceeded(authInfo)
+        } else {
+          FailureResponse
+        }
+      case _ => FailureResponse
+    }
+  }
+
+  private def downloadKey(header: JwtHeader): Option[String] = {
+    if (header.keyId.isEmpty) return None
+    val keyId = header.keyId.get
+    val request = HttpRequest(uri = s"$keyEndpoint$keyId")
+
+    val responseTry = Await.ready(Http().singleRequest(request), KeyEndpointTimeout).value.get
+    if (responseTry.isFailure) return None
+    val response = responseTry.get
+
+    val responseStringTry = Await.ready(Unmarshal(response.entity).to[String], KeyEndpointTimeout).value.get
+    if (responseStringTry.isFailure) return None
+
+    Some(responseStringTry.get)
+  }
+
+  private def parseKey(key: String): PublicKey = {
+    val strippedKey = key.replace(KeyHeaderBegin, "").replace(KeyHeaderEnd, "").replaceAll("\\n", "")
+    val keySpec = new X509EncodedKeySpec(Base64.getDecoder.decode(strippedKey))
+    val keyFactory = KeyFactory.getInstance("EC")
+    keyFactory.generatePublic(keySpec)
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
@@ -31,7 +31,7 @@ class BasicAuthentication(config: Config) extends HttpAuthentication {
         val receivedCredentials = BasicHttpCredentials(header.credentials.token())
 
         val authenticated = receivedCredentials.username == username && receivedCredentials.password == password
-        if (authenticated) AuthenticationSucceeded(AuthenticationInfo(Some(s"Logged in as: $username"), Seq.empty))
+        if (authenticated) AuthenticationSucceeded(AuthenticationInfo(Some(s"Logged in as: $username"), None, Seq.empty))
         else AuthenticationForbidden(HttpResponse(403))
       case None =>
         val header = `WWW-Authenticate`(List(HttpChallenge("basic", Some("SumoBot"))))

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend.authentication
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+
+class BasicAuthentication(username: String, password: String) extends HttpAuthentication {
+  override def routes: PartialFunction[HttpRequest, HttpResponse] = PartialFunction.empty
+
+  override def authentication(request: HttpRequest): AuthenticationResult = {
+    request.header[`Authorization`] match {
+      case Some(header) =>
+        val receivedCredentials = BasicHttpCredentials(header.credentials.token())
+
+        val authenticated = receivedCredentials.username == username && receivedCredentials.password == password
+        if (authenticated) AuthenticationSucceeded(AuthenticationInfo(Some(s"Logged in as: $username"), Seq.empty))
+        else AuthenticationForbidden(HttpResponse(403))
+      case None =>
+        val header = `WWW-Authenticate`(List(HttpChallenge("basic", Some("SumoBot"))))
+        AuthenticationForbidden(HttpResponse(401, headers = List(header)))
+    }
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
@@ -21,8 +21,6 @@ import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 
 class BasicAuthentication(username: String, password: String) extends HttpAuthentication {
-  override def routes: PartialFunction[HttpRequest, HttpResponse] = PartialFunction.empty
-
   override def authentication(request: HttpRequest): AuthenticationResult = {
     request.header[`Authorization`] match {
       case Some(header) =>

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
@@ -19,8 +19,12 @@
 package com.sumologic.sumobot.http_frontend.authentication
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import com.typesafe.config.Config
 
-class BasicAuthentication(username: String, password: String) extends HttpAuthentication {
+class BasicAuthentication(config: Config) extends HttpAuthentication {
+  private val username = config.getString("username")
+  private val password = config.getString("password")
+
   override def authentication(request: HttpRequest): AuthenticationResult = {
     request.header[`Authorization`] match {
       case Some(header) =>

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthentication.scala
@@ -17,6 +17,8 @@
  * under the License.
  */
 package com.sumologic.sumobot.http_frontend.authentication
+import java.security.MessageDigest
+
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import com.typesafe.config.Config
@@ -30,7 +32,8 @@ class BasicAuthentication(config: Config) extends HttpAuthentication {
       case Some(header) =>
         val receivedCredentials = BasicHttpCredentials(header.credentials.token())
 
-        val authenticated = receivedCredentials.username == username && receivedCredentials.password == password
+        val authenticated = MessageDigest.isEqual(receivedCredentials.username.getBytes, username.getBytes) &&
+          MessageDigest.isEqual(receivedCredentials.password.getBytes, password.getBytes)
         if (authenticated) AuthenticationSucceeded(AuthenticationInfo(Some(s"Logged in as: $username"), None, Seq.empty))
         else AuthenticationForbidden(HttpResponse(403))
       case None =>

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/HttpAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/HttpAuthentication.scala
@@ -22,11 +22,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 
 case class Link(name: String, href: String)
 
-case class AuthenticationInfo(authMessage: Option[String], authLinks: Seq[Link]) {
-  def toMap: Map[String, Any] = {
-    Map("authMessage" -> authMessage, "authLinks" -> authLinks)
-  }
-}
+case class AuthenticationInfo(authMessage: Option[String], authLinks: Seq[Link])
 
 sealed trait AuthenticationResult
 

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/HttpAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/HttpAuthentication.scala
@@ -22,7 +22,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 
 case class Link(name: String, href: String)
 
-case class AuthenticationInfo(authMessage: Option[String], authLinks: Seq[Link])
+case class AuthenticationInfo(authMessage: Option[String], authEmail: Option[String], authLinks: Seq[Link])
 
 sealed trait AuthenticationResult
 

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/HttpAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/HttpAuthentication.scala
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend.authentication
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+
+case class Link(name: String, href: String)
+
+case class AuthenticationInfo(message: Option[String], links: Seq[Link])
+
+sealed trait AuthenticationResult
+
+case class AuthenticationForbidden(response: HttpResponse) extends AuthenticationResult
+case class AuthenticationSucceeded(info: AuthenticationInfo) extends AuthenticationResult
+
+trait HttpAuthentication {
+  def routes: PartialFunction[HttpRequest, HttpResponse]
+  def authentication(request: HttpRequest): AuthenticationResult
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/HttpAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/HttpAuthentication.scala
@@ -30,6 +30,6 @@ case class AuthenticationForbidden(response: HttpResponse) extends Authenticatio
 case class AuthenticationSucceeded(info: AuthenticationInfo) extends AuthenticationResult
 
 trait HttpAuthentication {
-  def routes: PartialFunction[HttpRequest, HttpResponse]
+  def routes: PartialFunction[HttpRequest, HttpResponse] = PartialFunction.empty
   def authentication(request: HttpRequest): AuthenticationResult
 }

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthentication.scala
@@ -22,6 +22,6 @@ import com.typesafe.config.Config
 
 class NoAuthentication(config: Config) extends HttpAuthentication {
   override def authentication(request: HttpRequest): AuthenticationResult = {
-    AuthenticationSucceeded(AuthenticationInfo(None, Seq.empty))
+    AuthenticationSucceeded(AuthenticationInfo(None, None, Seq.empty))
   }
 }

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthentication.scala
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend.authentication
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+
+class NoAuthentication extends HttpAuthentication {
+  override def routes: PartialFunction[HttpRequest, HttpResponse] = PartialFunction.empty
+
+  override def authentication(request: HttpRequest): AuthenticationResult = {
+    AuthenticationSucceeded(AuthenticationInfo(None, Seq.empty))
+  }
+}

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthentication.scala
@@ -18,8 +18,9 @@
  */
 package com.sumologic.sumobot.http_frontend.authentication
 import akka.http.scaladsl.model.HttpRequest
+import com.typesafe.config.Config
 
-class NoAuthentication extends HttpAuthentication {
+class NoAuthentication(config: Config) extends HttpAuthentication {
   override def authentication(request: HttpRequest): AuthenticationResult = {
     AuthenticationSucceeded(AuthenticationInfo(None, Seq.empty))
   }

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthentication.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthentication.scala
@@ -17,11 +17,9 @@
  * under the License.
  */
 package com.sumologic.sumobot.http_frontend.authentication
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.HttpRequest
 
 class NoAuthentication extends HttpAuthentication {
-  override def routes: PartialFunction[HttpRequest, HttpResponse] = PartialFunction.empty
-
   override def authentication(request: HttpRequest): AuthenticationResult = {
     AuthenticationSucceeded(AuthenticationInfo(None, Seq.empty))
   }

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/RoutingHelperTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/RoutingHelperTest.scala
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpMethods.{GET, HEAD}
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, StatusCodes, Uri}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import com.sumologic.sumobot.test.SumoBotSpec
+import org.scalatest.BeforeAndAfterAll
+
+import scala.concurrent.duration._
+import scala.concurrent.Await
+
+class RoutingHelperTest extends TestKit(ActorSystem("RoutingHelperTest"))
+  with SumoBotSpec with BeforeAndAfterAll {
+
+  private implicit val materializer = ActorMaterializer()
+
+  private val origin = "https://www.sumologic.com"
+  private val routingHelper = new RoutingHelper(origin)
+
+  private val singleResponseRoute: PartialFunction[HttpRequest, HttpResponse] = {
+    case _: HttpRequest =>
+      HttpResponse(entity = "hello!", headers = List(RawHeader("test", "testing")))
+  }
+
+  private val singleResponseRouteWithAllowOrigin: PartialFunction[HttpRequest, HttpResponse] = {
+    case _: HttpRequest =>
+      HttpResponse(entity = "hello!", headers = List(`Access-Control-Allow-Origin`("https://www.example.com"), RawHeader("test", "testing")))
+  }
+
+  private val rootRoute: PartialFunction[HttpRequest, HttpResponse] = {
+    case HttpRequest(GET, Uri.Path("/"), _, _, _) =>
+      HttpResponse(entity = "hello!", headers = List(RawHeader("test", "testing")))
+
+    case HttpRequest(HEAD, Uri.Path("/head"), _, _, _) =>
+      HttpResponse(entity = "OK!")
+  }
+
+  private val emptyRequest = HttpRequest()
+  private val getRootRequest = HttpRequest(GET, Uri("/"))
+  private val unknownRequest = HttpRequest(GET, Uri("/invalid"))
+  private val headRequest = HttpRequest(HEAD, Uri("/"))
+  private val existingHeadRequest = HttpRequest(HEAD, Uri("/head"))
+
+  "RoutingHelper" can {
+    "withAllowOriginHeader" should {
+      "add new AllowOrigin header" in {
+        val headers = routingHelper.withAllowOriginHeader(singleResponseRoute)(emptyRequest).headers
+
+        headers should contain(`Access-Control-Allow-Origin`(origin))
+        headers should contain(RawHeader("test", "testing"))
+      }
+
+      "replace old AllowOrigin header" in {
+        val headers = routingHelper.withAllowOriginHeader(singleResponseRouteWithAllowOrigin)(emptyRequest).headers
+
+        headers should contain(`Access-Control-Allow-Origin`(origin))
+        headers should contain(RawHeader("test", "testing"))
+      }
+    }
+
+    "withForbiddenFallback" should {
+      "not modify valid requests" in {
+        val response = routingHelper.withForbiddenFallback(rootRoute)(getRootRequest).entity
+
+        entityToString(response) should be ("hello!")
+      }
+
+      "respond with 403" in {
+        val response = routingHelper.withForbiddenFallback(rootRoute)(unknownRequest)
+
+        response.status should be (StatusCodes.Forbidden)
+        response.headers should not contain RawHeader("test", "testing")
+      }
+    }
+
+    "withHeadRequests" should {
+      "return valid HEAD response" in {
+        val response = routingHelper.withHeadRequests(rootRoute)(headRequest)
+
+        response.status should be (StatusCodes.OK)
+        entityToString(response.entity).isEmpty should be (true)
+
+        response.headers should contain(RawHeader("test", "testing"))
+      }
+
+      "passthrough existing HEAD respones" in {
+        val response = routingHelper.withHeadRequests(rootRoute)(existingHeadRequest)
+
+        response.status should be (StatusCodes.OK)
+        entityToString(response.entity) should be ("OK!")
+      }
+    }
+  }
+
+  private def entityToString(httpEntity: HttpEntity): String = {
+    Await.result(Unmarshal(httpEntity).to[String], 5.seconds)
+  }
+
+  override def afterAll: Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+}

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/RoutingHelperTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/RoutingHelperTest.scala
@@ -39,6 +39,8 @@ class RoutingHelperTest extends TestKit(ActorSystem("RoutingHelperTest"))
   private val origin = "https://www.sumologic.com"
   private val routingHelper = new RoutingHelper(origin)
 
+  private val wildcardRoutingHelper = new RoutingHelper("*")
+
   private val singleResponseRoute: PartialFunction[HttpRequest, HttpResponse] = {
     case _: HttpRequest =>
       HttpResponse(entity = "hello!", headers = List(RawHeader("test", "testing")))
@@ -76,6 +78,13 @@ class RoutingHelperTest extends TestKit(ActorSystem("RoutingHelperTest"))
         val headers = routingHelper.withAllowOriginHeader(singleResponseRouteWithAllowOrigin)(emptyRequest).headers
 
         headers should contain(`Access-Control-Allow-Origin`(origin))
+        headers should contain(RawHeader("test", "testing"))
+      }
+
+      "handle wildcard origin" in {
+        val headers = wildcardRoutingHelper.withAllowOriginHeader(singleResponseRoute)(emptyRequest).headers
+
+        headers should contain(`Access-Control-Allow-Origin`.*)
         headers should contain(RawHeader("test", "testing"))
       }
     }

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerOptionsTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerOptionsTest.scala
@@ -20,6 +20,7 @@ package com.sumologic.sumobot.http_frontend
 
 import java.util.Properties
 
+import com.sumologic.sumobot.http_frontend.SumoBotHttpServerOptions._
 import com.sumologic.sumobot.http_frontend.authentication.BasicAuthentication
 import com.sumologic.sumobot.test.SumoBotSpec
 import com.typesafe.config.ConfigFactory
@@ -33,12 +34,15 @@ class SumoBotHttpServerOptionsTest extends SumoBotSpec {
 
       val config = ConfigFactory.parseProperties(props)
 
-      val options = SumoBotHttpServerOptions.fromConfig(config)
+      val options = fromConfig(config)
 
       options.httpHost should be ("localhost")
       options.httpPort should be (9999)
-      options.origin should be (SumoBotHttpServer.DefaultOrigin)
-      options.authentication should be (SumoBotHttpServer.DefaultAuthentication)
+      options.origin should be (DefaultOrigin)
+      options.authentication should be (DefaultAuthentication)
+      options.title should be (DefaultTitle)
+      options.description should be (None)
+      options.links.isEmpty should be (true)
     }
 
     "parse config with host, port, origin" in {
@@ -49,12 +53,15 @@ class SumoBotHttpServerOptionsTest extends SumoBotSpec {
 
       val config = ConfigFactory.parseProperties(props)
 
-      val options = SumoBotHttpServerOptions.fromConfig(config)
+      val options = fromConfig(config)
 
       options.httpHost should be ("localhost")
       options.httpPort should be (9999)
       options.origin should be ("*")
-      options.authentication should be (SumoBotHttpServer.DefaultAuthentication)
+      options.authentication should be (DefaultAuthentication)
+      options.title should be (DefaultTitle)
+      options.description should be (None)
+      options.links.isEmpty should be (true)
     }
 
     "parse config with host, port, origin, basic-authentication" in {
@@ -62,17 +69,69 @@ class SumoBotHttpServerOptionsTest extends SumoBotSpec {
       props.setProperty("host", "localhost")
       props.setProperty("port", "9999")
       props.setProperty("origin", "https://sumologic.com")
-      props.setProperty("basic-authentication.username", "admin")
-      props.setProperty("basic-authentication.password", "hunter2")
+      props.setProperty("authentication.enabled", "true")
+      props.setProperty("authentication.class", "com.sumologic.sumobot.http_frontend.authentication.BasicAuthentication")
+      props.setProperty("authentication.username", "admin")
+      props.setProperty("authentication.password", "hunter2")
 
       val config = ConfigFactory.parseProperties(props)
 
-      val options = SumoBotHttpServerOptions.fromConfig(config)
+      val options = fromConfig(config)
 
       options.httpHost should be ("localhost")
       options.httpPort should be (9999)
       options.origin should be ("https://sumologic.com")
       options.authentication shouldBe a[BasicAuthentication]
+      options.title should be (DefaultTitle)
+      options.description should be (None)
+      options.links.isEmpty should be (true)
+    }
+
+    "parse config with host, port, origin, basic-authentication disabled" in {
+      val props = new Properties()
+      props.setProperty("host", "localhost")
+      props.setProperty("port", "9999")
+      props.setProperty("origin", "https://sumologic.com")
+      props.setProperty("authentication.enabled", "false")
+      props.setProperty("authentication.class", "com.sumologic.sumobot.http_frontend.authentication.BasicAuthentication")
+      props.setProperty("authentication.username", "admin")
+      props.setProperty("authentication.password", "hunter2")
+
+      val config = ConfigFactory.parseProperties(props)
+
+      val options = fromConfig(config)
+
+      options.httpHost should be ("localhost")
+      options.httpPort should be (9999)
+      options.origin should be ("https://sumologic.com")
+      options.authentication should be (DefaultAuthentication)
+      options.title should be (DefaultTitle)
+      options.description should be (None)
+      options.links.isEmpty should be (true)
+    }
+
+    "parse config with host, port, title, description, links" in {
+      val props = new Properties()
+      props.setProperty("host", "localhost")
+      props.setProperty("port", "9999")
+      props.setProperty("title", "My Title")
+      props.setProperty("description", "My Description")
+      props.setProperty("links.link1.name", "Sumo Logic")
+      props.setProperty("links.link1.href", "https://sumologic.com")
+
+      val config = ConfigFactory.parseProperties(props)
+
+      val options = fromConfig(config)
+
+      options.httpHost should be ("localhost")
+      options.httpPort should be (9999)
+      options.origin should be (DefaultOrigin)
+      options.authentication should be (DefaultAuthentication)
+      options.title should be ("My Title")
+      options.description should be (Some("My Description"))
+      options.links.length should be (1)
+      options.links.head.name should be ("Sumo Logic")
+      options.links.head.href should be ("https://sumologic.com")
     }
   }
 }

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerOptionsTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerOptionsTest.scala
@@ -130,8 +130,8 @@ class SumoBotHttpServerOptionsTest extends SumoBotSpec {
       options.title should be ("My Title")
       options.description should be (Some("My Description"))
       options.links.length should be (1)
-      options.links.head.name should be ("Sumo Logic")
-      options.links.head.href should be ("https://sumologic.com")
+      options.links(0).name should be ("Sumo Logic")
+      options.links(0).href should be ("https://sumologic.com")
     }
   }
 }

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerOptionsTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerOptionsTest.scala
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend
+
+import java.util.Properties
+
+import com.sumologic.sumobot.http_frontend.authentication.BasicAuthentication
+import com.sumologic.sumobot.test.SumoBotSpec
+import com.typesafe.config.ConfigFactory
+
+class SumoBotHttpServerOptionsTest extends SumoBotSpec {
+  "SumoBotHttpServerOptions" should {
+    "parse config with host, port" in {
+      val props = new Properties()
+      props.setProperty("host", "localhost")
+      props.setProperty("port", "9999")
+
+      val config = ConfigFactory.parseProperties(props)
+
+      val options = SumoBotHttpServerOptions.fromConfig(config)
+
+      options.httpHost should be ("localhost")
+      options.httpPort should be (9999)
+      options.origin should be (SumoBotHttpServer.DefaultOrigin)
+      options.authentication should be (SumoBotHttpServer.DefaultAuthentication)
+    }
+
+    "parse config with host, port, origin" in {
+      val props = new Properties()
+      props.setProperty("host", "localhost")
+      props.setProperty("port", "9999")
+      props.setProperty("origin", "*")
+
+      val config = ConfigFactory.parseProperties(props)
+
+      val options = SumoBotHttpServerOptions.fromConfig(config)
+
+      options.httpHost should be ("localhost")
+      options.httpPort should be (9999)
+      options.origin should be ("*")
+      options.authentication should be (SumoBotHttpServer.DefaultAuthentication)
+    }
+
+    "parse config with host, port, origin, basic-authentication" in {
+      val props = new Properties()
+      props.setProperty("host", "localhost")
+      props.setProperty("port", "9999")
+      props.setProperty("origin", "https://sumologic.com")
+      props.setProperty("basic-authentication.username", "admin")
+      props.setProperty("basic-authentication.password", "hunter2")
+
+      val config = ConfigFactory.parseProperties(props)
+
+      val options = SumoBotHttpServerOptions.fromConfig(config)
+
+      options.httpHost should be ("localhost")
+      options.httpPort should be (9999)
+      options.origin should be ("https://sumologic.com")
+      options.authentication shouldBe a[BasicAuthentication]
+    }
+  }
+}

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
@@ -36,6 +36,7 @@ import com.sumologic.sumobot.plugins.PluginsFromProps
 import com.sumologic.sumobot.plugins.help.Help
 import com.sumologic.sumobot.plugins.system.System
 import com.sumologic.sumobot.test.SumoBotSpec
+import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
@@ -51,7 +52,8 @@ class SumoBotHttpServerTest
   private val host = "localhost"
   private val port = 9999
   private val origin = "https://sumologic.com"
-  private val httpServerOptions = SumoBotHttpServerOptions(host, port, origin, new NoAuthentication())
+  private val httpServerOptions = SumoBotHttpServerOptions(host, port, origin,
+    new NoAuthentication(ConfigFactory.empty()), "", None, Seq.empty)
   private val httpServer = new SumoBotHttpServer(httpServerOptions)
 
   private val brain = TestActorRef(Props[InMemoryBrain])

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
@@ -21,7 +21,7 @@ package com.sumologic.sumobot.http_frontend
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.ContentTypes._
-import akka.http.scaladsl.model.HttpMethods.{GET, OPTIONS, HEAD}
+import akka.http.scaladsl.model.HttpMethods.{GET, HEAD, OPTIONS}
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
 import akka.http.scaladsl.model._
@@ -31,6 +31,7 @@ import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import com.sumologic.sumobot.brain.InMemoryBrain
 import com.sumologic.sumobot.core.{Bootstrap, HttpReceptionist}
+import com.sumologic.sumobot.http_frontend.authentication.NoAuthentication
 import com.sumologic.sumobot.plugins.PluginsFromProps
 import com.sumologic.sumobot.plugins.help.Help
 import com.sumologic.sumobot.plugins.system.System
@@ -50,7 +51,8 @@ class SumoBotHttpServerTest
   private val host = "localhost"
   private val port = 9999
   private val origin = "https://sumologic.com"
-  private val httpServer = new SumoBotHttpServer(host, port, origin)
+  private val httpServerOptions = SumoBotHttpServerOptions(host, port, origin, new NoAuthentication())
+  private val httpServer = new SumoBotHttpServer(httpServerOptions)
 
   private val brain = TestActorRef(Props[InMemoryBrain])
   private val httpReceptionist = TestActorRef(new HttpReceptionist(brain))

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
@@ -80,7 +80,7 @@ class SumoBotHttpServerTest
           (response, responseString) =>
             response.status should be (StatusCodes.OK)
             response.header[`Content-Type`] should be(Some(`Content-Type`(ContentType(MediaTypes.`application/javascript`, HttpCharsets.`UTF-8`))))
-            responseString should include("window.onload")
+            responseString should include("window.addEventListener")
         }
       }
 

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
@@ -56,10 +56,13 @@ class SumoBotHttpServerTest
 
   private val brain = TestActorRef(Props[InMemoryBrain])
   private val httpReceptionist = TestActorRef(new HttpReceptionist(brain))
-  Bootstrap.receptionist = Some(httpReceptionist)
 
   private val pluginCollection = PluginsFromProps(Array(Props(classOf[Help]), Props(classOf[System])))
-  pluginCollection.setup
+
+  override def beforeAll: Unit = {
+    Bootstrap.receptionist = Some(httpReceptionist)
+    pluginCollection.setup
+  }
 
   "SumoBotHttpServer" should {
     "handle static pages requests" when {
@@ -226,7 +229,7 @@ class SumoBotHttpServerTest
 
   override def afterAll: Unit = {
     httpServer.terminate()
-    TestKit.shutdownActorSystem(system)
     Bootstrap.receptionist = None
+    TestKit.shutdownActorSystem(system, 10.seconds, true)
   }
 }

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
@@ -20,9 +20,11 @@ package com.sumologic.sumobot.http_frontend
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.headers.`Content-Type`
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.HttpMethods.{GET, OPTIONS, HEAD}
+import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
-import akka.http.scaladsl.model.{ContentTypes, HttpRequest, HttpResponse, StatusCodes}
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
@@ -35,9 +37,8 @@ import com.sumologic.sumobot.plugins.system.System
 import com.sumologic.sumobot.test.SumoBotSpec
 import org.scalatest.BeforeAndAfterAll
 
-import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration._
-import akka.http.scaladsl.model.ContentTypes._
+import scala.concurrent.{Await, Promise}
 
 class SumoBotHttpServerTest
   extends TestKit(ActorSystem("SumoBotHttpServerTest"))
@@ -48,7 +49,8 @@ class SumoBotHttpServerTest
 
   private val host = "localhost"
   private val port = 9999
-  private val httpServer = new SumoBotHttpServer(host, port)
+  private val origin = "https://sumologic.com"
+  private val httpServer = new SumoBotHttpServer(host, port, origin)
 
   private val brain = TestActorRef(Props[InMemoryBrain])
   private val httpReceptionist = TestActorRef(new HttpReceptionist(brain))
@@ -68,12 +70,12 @@ class SumoBotHttpServerTest
         }
       }
 
-      "accessing /index.html" in {
-        sendHttpRequest("/index.html") {
+      "accessing /script.js" in {
+        sendHttpRequest("/script.js") {
           (response, responseString) =>
             response.status should be (StatusCodes.OK)
-            response.header[`Content-Type`] should be(Some(`Content-Type`(`text/html(UTF-8)`)))
-            responseString should include("<!doctype html>")
+            response.header[`Content-Type`] should be(Some(`Content-Type`(ContentType(MediaTypes.`application/javascript`, HttpCharsets.`UTF-8`))))
+            responseString should include("window.onload")
         }
       }
 
@@ -130,10 +132,60 @@ class SumoBotHttpServerTest
         disconnectPromise.success(None)
       }
     }
+
+    "send proper AllowOrigin header" when {
+      "sending HTTP request" in {
+        sendHttpRequest("/") {
+          (response, _) =>
+            response.header[`Access-Control-Allow-Origin`] should be (Some(`Access-Control-Allow-Origin`(origin)))
+        }
+      }
+
+      "sending WebSocket request" in {
+        val sink = Sink.ignore
+        val source = Source.maybe[Message]
+
+        val (upgradeResponse, disconnectPromise) = Http().singleWebSocketRequest(webSocketRequest,
+          Flow.fromSinkAndSourceMat(sink, source)(Keep.right))
+
+        val httpResponse = Await.result(upgradeResponse, 5.seconds).response
+
+        httpResponse.header[`Access-Control-Allow-Origin`] should be (Some(`Access-Control-Allow-Origin`(origin)))
+
+        disconnectPromise.success(None)
+      }
+    }
+
+    "handle OPTIONS requests" when {
+      "accessing root page" in {
+        sendHttpRequest("/", method = OPTIONS) {
+          (response, _) =>
+            response.status should be (StatusCodes.OK)
+            response.header[`Access-Control-Allow-Methods`] should be (Some(`Access-Control-Allow-Methods`(List(GET))))
+        }
+      }
+
+      "accessing WebSocket endpoint" in {
+        sendHttpRequest("/websocket", method = OPTIONS) {
+          (response, _) =>
+            response.status should be (StatusCodes.OK)
+            response.header[`Access-Control-Allow-Methods`] should be (Some(`Access-Control-Allow-Methods`(List(GET))))
+        }
+      }
+    }
+
+    "handle HEAD requests" in {
+      sendHttpRequest("/", method = HEAD) {
+        (response, _) =>
+          response.status should be (StatusCodes.OK)
+          response.header[`Content-Type`] should be(Some(`Content-Type`(`text/html(UTF-8)`)))
+          entityToString(response.entity).isEmpty should be (true)
+      }
+    }
   }
 
-  private def sendHttpRequest(path: String)(handler: (HttpResponse, String) => Unit): Unit = {
-    val responseFuture = Http().singleRequest(httpRequest(path))
+  private def sendHttpRequest(path: String, method: HttpMethod = GET)(handler: (HttpResponse, String) => Unit): Unit = {
+    val responseFuture = Http().singleRequest(httpRequest(path, method))
     Await.result(responseFuture, 5.seconds) match {
       case response: HttpResponse =>
         val responseStringFuture = Unmarshal(response.entity).to[String]
@@ -160,8 +212,12 @@ class SumoBotHttpServerTest
     sendWebSocketMessages(Array(msg), listenerRef)
   }
 
-  private def httpRequest(path: String): HttpRequest = {
-    HttpRequest(uri = s"http://$host:$port$path")
+  private def httpRequest(path: String, method: HttpMethod): HttpRequest = {
+    HttpRequest(uri = s"http://$host:$port$path", method = method)
+  }
+
+  private def entityToString(httpEntity: HttpEntity): String = {
+    Await.result(Unmarshal(httpEntity).to[String], 5.seconds)
   }
 
   private val webSocketRequest = WebSocketRequest(s"ws://$host:$port/websocket")

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/AuthenticatedServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/AuthenticatedServerTest.scala
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend.authentication
+
+import akka.actor.{ActorSystem, Props}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.HttpMethods.GET
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.ws.{Message, WebSocketRequest}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.testkit.{TestActorRef, TestKit}
+import com.sumologic.sumobot.brain.InMemoryBrain
+import com.sumologic.sumobot.core.{Bootstrap, HttpReceptionist}
+import com.sumologic.sumobot.http_frontend.{SumoBotHttpServer, SumoBotHttpServerOptions}
+import com.sumologic.sumobot.plugins.PluginsFromProps
+import com.sumologic.sumobot.plugins.help.Help
+import com.sumologic.sumobot.plugins.system.System
+import com.sumologic.sumobot.test.SumoBotSpec
+import org.scalatest.BeforeAndAfterAll
+
+import scala.collection.immutable
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class AuthenticatedServerTest
+  extends TestKit(ActorSystem("AuthenticatedServerTest"))
+    with SumoBotSpec
+    with BeforeAndAfterAll {
+  private implicit val materializer = ActorMaterializer()
+
+  private val host = "localhost"
+  private val port = 10000
+  private val origin = "https://sumologic.com"
+
+  private val basicAuthentication = new BasicAuthentication("admin", "hunter2")
+  private val base64Credentials = "YWRtaW46aHVudGVyMg=="
+  private val base64InvalidCredentials = "YWRtaW46aHVpdGVyMg=="
+
+  private val rootPageRequest = httpRequest("/", GET)
+  private val stylePageRequest = httpRequest("/style.css", GET)
+  private val validRootPageRequest = httpRequest("/", GET, List(`Authorization`(GenericHttpCredentials("basic", base64Credentials))))
+  private val invalidRootPageRequest = httpRequest("/", GET, List(`Authorization`(GenericHttpCredentials("basic", base64InvalidCredentials))))
+
+  private val webSocketRequest = WebSocketRequest(s"ws://$host:$port/websocket")
+  private val authWebSocketRequest = WebSocketRequest(s"ws://$host:$port/websocket",
+    extraHeaders = List(`Authorization`(GenericHttpCredentials("basic", base64Credentials))))
+
+  private val httpServerOptions = SumoBotHttpServerOptions(host, port, origin, basicAuthentication)
+  private val httpServer = new SumoBotHttpServer(httpServerOptions)
+
+  private val brain = TestActorRef(Props[InMemoryBrain])
+  private val httpReceptionist = TestActorRef(new HttpReceptionist(brain))
+
+  private val pluginCollection = PluginsFromProps(Array(Props(classOf[Help]), Props(classOf[System])))
+
+  override def beforeAll: Unit = {
+    Bootstrap.receptionist = Some(httpReceptionist)
+    pluginCollection.setup
+  }
+
+  "authenticated SumoBotHttpServer" should {
+    "deny unauthenticated requests" when {
+      "accessing root page" in {
+        val response = sendHttpRequest(rootPageRequest)
+        response.status should be(StatusCodes.Unauthorized)
+      }
+
+      "accessing root page with invalid credentials" in {
+        val response = sendHttpRequest(invalidRootPageRequest)
+        response.status should be(StatusCodes.Forbidden)
+      }
+
+      "accessing /style.css" in {
+        val response = sendHttpRequest(stylePageRequest)
+        response.status should be(StatusCodes.Unauthorized)
+      }
+
+      "accessing /websocket" in {
+        webSocketResponse(webSocketRequest).status should be (StatusCodes.Unauthorized)
+      }
+    }
+
+    "allow authenticated requests" when {
+      "accessing root page" in {
+        val response = sendHttpRequest(validRootPageRequest)
+        response.status should be(StatusCodes.OK)
+        response.header[`Content-Type`] should be(Some(`Content-Type`(`text/html(UTF-8)`)))
+
+        entityToString(response.entity) should include("<!doctype html>")
+      }
+
+      "accessing /websocket" in {
+        webSocketResponse(authWebSocketRequest).status should be (StatusCodes.SwitchingProtocols)
+      }
+    }
+  }
+
+  private def sendHttpRequest(httpRequest: HttpRequest): HttpResponse = {
+    val responseFuture = Http().singleRequest(httpRequest)
+    Await.result(responseFuture, 5.seconds) match {
+      case response: HttpResponse =>
+        response
+      case _ =>
+        fail("expected HttpResponse")
+    }
+  }
+
+  private def entityToString(httpEntity: HttpEntity): String = {
+    Await.result(Unmarshal(httpEntity).to[String], 5.seconds)
+  }
+
+  private def httpRequest(path: String, method: HttpMethod, headers: immutable.Seq[HttpHeader] = immutable.Seq.empty): HttpRequest = {
+    HttpRequest(uri = s"http://$host:$port$path", method = method, headers = headers)
+  }
+
+  private def webSocketResponse(request: WebSocketRequest): HttpResponse = {
+    val sink = Sink.ignore
+    val source = Source.maybe[Message]
+
+    val (upgradeResponse, disconnectPromise) = Http().singleWebSocketRequest(request,
+      Flow.fromSinkAndSourceMat(sink, source)(Keep.right))
+
+    val httpResponse = Await.result(upgradeResponse, 5.seconds).response
+
+    disconnectPromise.success(None)
+
+    httpResponse
+  }
+
+  override def afterAll: Unit = {
+    httpServer.terminate()
+    Bootstrap.receptionist = None
+    TestKit.shutdownActorSystem(system, 10.seconds, true)
+  }
+}

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/AuthenticatedServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/AuthenticatedServerTest.scala
@@ -36,11 +36,13 @@ import com.sumologic.sumobot.plugins.PluginsFromProps
 import com.sumologic.sumobot.plugins.help.Help
 import com.sumologic.sumobot.plugins.system.System
 import com.sumologic.sumobot.test.SumoBotSpec
+import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.collection.JavaConverters._
 
 class AuthenticatedServerTest
   extends TestKit(ActorSystem("AuthenticatedServerTest"))
@@ -52,7 +54,10 @@ class AuthenticatedServerTest
   private val port = 10000
   private val origin = "https://sumologic.com"
 
-  private val basicAuthentication = new BasicAuthentication("admin", "hunter2")
+  private val authConfig = ConfigFactory.parseMap(
+    Map("username" -> "admin", "password" -> "hunter2").asJava)
+
+  private val basicAuthentication = new BasicAuthentication(authConfig)
   private val base64Credentials = "YWRtaW46aHVudGVyMg=="
   private val base64InvalidCredentials = "YWRtaW46aHVpdGVyMg=="
 
@@ -65,7 +70,7 @@ class AuthenticatedServerTest
   private val authWebSocketRequest = WebSocketRequest(s"ws://$host:$port/websocket",
     extraHeaders = List(`Authorization`(GenericHttpCredentials("basic", base64Credentials))))
 
-  private val httpServerOptions = SumoBotHttpServerOptions(host, port, origin, basicAuthentication)
+  private val httpServerOptions = SumoBotHttpServerOptions(host, port, origin, basicAuthentication, "", None, Seq.empty)
   private val httpServer = new SumoBotHttpServer(httpServerOptions)
 
   private val brain = TestActorRef(Props[InMemoryBrain])

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
@@ -51,7 +51,7 @@ class BasicAuthenticationTest extends SumoBotSpec {
         val result = basicAuthentication.authentication(authorizedRootRequest)
         result match {
           case AuthenticationSucceeded(info) =>
-            info.message.get should include("admin")
+            info.authMessage.get should include("admin")
           case _ =>
             fail("expected AuthenticationSucceeded")
         }

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
@@ -22,9 +22,13 @@ import akka.http.scaladsl.model.HttpMethods.{GET, POST}
 import akka.http.scaladsl.model.{HttpRequest, StatusCodes, Uri}
 import com.sumologic.sumobot.test.SumoBotSpec
 import akka.http.scaladsl.model.headers._
+import com.typesafe.config.ConfigFactory
+import scala.collection.JavaConverters._
 
 class BasicAuthenticationTest extends SumoBotSpec {
-  val basicAuthentication = new BasicAuthentication("admin", "hunter2")
+  private val authConfig = ConfigFactory.parseMap(
+    Map("username" -> "admin", "password" -> "hunter2").asJava)
+  val basicAuthentication = new BasicAuthentication(authConfig)
   val base64Credentials = "YWRtaW46aHVudGVyMg=="
   val base64InvalidCredentials = "YWRtaW46aHVpdGVyMg=="
 

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
@@ -55,7 +55,11 @@ class BasicAuthenticationTest extends SumoBotSpec {
         val result = basicAuthentication.authentication(authorizedRootRequest)
         result match {
           case AuthenticationSucceeded(info) =>
-            info.authMessage.get should include("admin")
+            info.authMessage match {
+              case Some(message) =>
+                message should include("admin")
+              case _ => fail("expected authMessage")
+            }
           case _ =>
             fail("expected AuthenticationSucceeded")
         }

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
@@ -34,7 +34,7 @@ class BasicAuthenticationTest extends SumoBotSpec {
 
   "BasicAuthentication" should {
       "return 401 Unauthorized" when {
-        "unauthorized" in {
+        "unauthenticated" in {
           val result = basicAuthentication.authentication(rootRequest)
           result match {
             case AuthenticationForbidden(response) =>
@@ -46,7 +46,7 @@ class BasicAuthenticationTest extends SumoBotSpec {
         }
       }
 
-    "successfuly authorize" when {
+    "successfuly authenticate" when {
       "provided correct Authorization header" in {
         val result = basicAuthentication.authentication(authorizedRootRequest)
         result match {

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/BasicAuthenticationTest.scala
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend.authentication
+
+import akka.http.scaladsl.model.HttpMethods.{GET, POST}
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes, Uri}
+import com.sumologic.sumobot.test.SumoBotSpec
+import akka.http.scaladsl.model.headers._
+
+class BasicAuthenticationTest extends SumoBotSpec {
+  val basicAuthentication = new BasicAuthentication("admin", "hunter2")
+  val base64Credentials = "YWRtaW46aHVudGVyMg=="
+  val base64InvalidCredentials = "YWRtaW46aHVpdGVyMg=="
+
+  val rootRequest = HttpRequest(GET, Uri("/"))
+  val authorizedRootRequest = rootRequest.withHeaders(List(`Authorization`(GenericHttpCredentials("basic", base64Credentials))))
+  val invalidRootRequest = rootRequest.withHeaders(List(`Authorization`(GenericHttpCredentials("basic", base64InvalidCredentials))))
+
+  "BasicAuthentication" should {
+      "return 401 Unauthorized" when {
+        "unauthorized" in {
+          val result = basicAuthentication.authentication(rootRequest)
+          result match {
+            case AuthenticationForbidden(response) =>
+              response.status should be(StatusCodes.Unauthorized)
+              response.header[`WWW-Authenticate`].nonEmpty should be(true)
+            case _ =>
+              fail("expected AuthenticationForbidden")
+          }
+        }
+      }
+
+    "successfuly authorize" when {
+      "provided correct Authorization header" in {
+        val result = basicAuthentication.authentication(authorizedRootRequest)
+        result match {
+          case AuthenticationSucceeded(info) =>
+            info.message.get should include("admin")
+          case _ =>
+            fail("expected AuthenticationSucceeded")
+        }
+      }
+    }
+
+    "return 403 Forbidden" when {
+      "provided incorrect Authorization header" in {
+        val result = basicAuthentication.authentication(invalidRootRequest)
+        result match {
+          case AuthenticationForbidden(response) =>
+            response.status should be(StatusCodes.Forbidden)
+          case _ =>
+            fail("expected AuthenticationForbidden")
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthenticationTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthenticationTest.scala
@@ -21,13 +21,14 @@ package com.sumologic.sumobot.http_frontend.authentication
 import akka.http.scaladsl.model.HttpMethods.{GET, POST}
 import akka.http.scaladsl.model.{HttpRequest, Uri}
 import com.sumologic.sumobot.test.SumoBotSpec
+import com.typesafe.config.ConfigFactory
 
 class NoAuthenticationTest extends SumoBotSpec {
   val emptyRequest = HttpRequest()
   val rootRequest = HttpRequest(GET, Uri("/"))
   val postRequest = HttpRequest(POST, Uri("/endpoint"))
 
-  val noAuthentication = new NoAuthentication()
+  val noAuthentication = new NoAuthentication(ConfigFactory.empty())
 
   "NoAuthentication" should {
     "allow all requests" in {

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthenticationTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/authentication/NoAuthenticationTest.scala
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.sumobot.http_frontend.authentication
+
+import akka.http.scaladsl.model.HttpMethods.{GET, POST}
+import akka.http.scaladsl.model.{HttpRequest, Uri}
+import com.sumologic.sumobot.test.SumoBotSpec
+
+class NoAuthenticationTest extends SumoBotSpec {
+  val emptyRequest = HttpRequest()
+  val rootRequest = HttpRequest(GET, Uri("/"))
+  val postRequest = HttpRequest(POST, Uri("/endpoint"))
+
+  val noAuthentication = new NoAuthentication()
+
+  "NoAuthentication" should {
+    "allow all requests" in {
+      noAuthentication.authentication(emptyRequest) shouldBe a[AuthenticationSucceeded]
+      noAuthentication.authentication(rootRequest) shouldBe a[AuthenticationSucceeded]
+      noAuthentication.authentication(postRequest) shouldBe a[AuthenticationSucceeded]
+    }
+  }
+}


### PR DESCRIPTION
- Added pluggable authentication system (optional in config):
    - No authentication (default)
    - Basic HTTP Auth (username + password)
    - AWS ALB OpenID authentication

Example:
```
  # HTTP Basic Authentication
  # authentication {
  #   enabled = true
  #   class = "com.sumologic.sumobot.http_frontend.authentication.BasicAuthentication"
  #   username = "..."
  #   password = "..."
  # }
```

- Added CORS support (Access-Control-Allow-Origin header)
- Implemented HEAD, OPTIONS methods
- Added ability to disable frontends (`enabled = false`) while maintaining backwards compatibility with previous config format:
```
http {
    enabled = false
    host = "localhost"
    port = 80
}
```
- Added page customization config (optional):
```
  # UI customization (shown in top bar):

  # title = "..."
  # description = "..."
  # links {
  #   mylink1 {
  #     name = "..."
  #     href = "..."
  #   }
  #   ...
  # }
```

##### New dependencies reasons:
- `scalate`: for dynamic page templates - manual page generation would be cumbersome, library jar is only ~1MB
- `jwt-play`: for parsing JWT token in AWS ALB OpenID authentication