### PR TITLE
sumobot-over-HTTP: Multiuser support

### DIFF
--- a/src/main/scala/com/sumologic/sumobot/http_frontend/HttpOutcomingSender.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/HttpOutcomingSender.scala
@@ -20,15 +20,16 @@ package com.sumologic.sumobot.http_frontend
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import akka.http.scaladsl.model.ws.TextMessage
-import com.sumologic.sumobot.core.model.OutgoingMessage
+import com.sumologic.sumobot.core.model.{Channel, OutgoingMessage}
 
-class HttpOutcomingSender(publisherRef: ActorRef) extends Actor with ActorLogging {
+class HttpOutcomingSender(publisherRef: ActorRef, connectionChannel: Channel) extends Actor with ActorLogging {
   override def preStart(): Unit = {
     Seq(classOf[OutgoingMessage]).foreach(context.system.eventStream.subscribe(self, _))
   }
 
   override def receive: Receive = {
-    case OutgoingMessage(_, text, _) =>
+    case OutgoingMessage(channel, text, _)
+      if channel == connectionChannel =>
       publisherRef ! TextMessage(text)
   }
 

--- a/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
+++ b/src/main/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServer.scala
@@ -170,6 +170,7 @@ class SumoBotHttpServer(options: SumoBotHttpServerOptions)(implicit system: Acto
     upgrade.handleMessagesWithSinkSource(sink, publisherSource)
   }
 
+  // TODO(pgrabowski, 2019-08-07): New channels and users are created here, but RtmState in BotPlugin is not updated.
   private def temporaryChannel(): PublicChannel = {
     val channelName = s"C${"%08d".format(connectionNumber)}"
 

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/HttpIncomingReceiverTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/HttpIncomingReceiverTest.scala
@@ -38,7 +38,8 @@ class HttpIncomingReceiverTest
   system.eventStream.subscribe(probe.ref, classOf[IncomingMessage])
 
   private val dummyActor = TestActorRef(TestActors.blackholeProps)
-  private val httpIncomingReceiver = TestActorRef(new HttpIncomingReceiver(dummyActor))
+  private val httpIncomingReceiver = TestActorRef(new HttpIncomingReceiver(dummyActor,
+    HttpReceptionist.DefaultSumoBotChannel, HttpReceptionist.DefaultClientUser))
 
   "HttpIncomingReceiver" should {
     "publish IncomingMessage" when {
@@ -89,7 +90,8 @@ class HttpIncomingReceiverTest
         val testProbeOutcoming = TestProbe()
         testProbeOutcoming.watch(outcomingActor)
 
-        val shutdownReceiver = TestActorRef(new HttpIncomingReceiver(outcomingActor))
+        val shutdownReceiver = TestActorRef(new HttpIncomingReceiver(outcomingActor,
+          HttpReceptionist.DefaultSumoBotChannel, HttpReceptionist.DefaultClientUser))
         val testProbeShutdown = TestProbe()
         testProbeShutdown.watch(shutdownReceiver)
 

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/HttpOutcomingSenderTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/HttpOutcomingSenderTest.scala
@@ -34,7 +34,7 @@ class HttpOutcomingSenderTest
   private val probe = new TestProbe(system)
   system.eventStream.subscribe(probe.ref, classOf[TextMessage.Strict])
 
-  private val httpOutcomingSender = TestActorRef(new HttpOutcomingSender(probe.ref))
+  private val httpOutcomingSender = TestActorRef(new HttpOutcomingSender(probe.ref, HttpReceptionist.DefaultSumoBotChannel))
 
   "HttpOutcomingSender" should {
     "send TextMessage" when {
@@ -54,7 +54,7 @@ class HttpOutcomingSenderTest
         val testProbe = TestProbe()
         testProbe.watch(dummyActor)
 
-        val stoppedSender = TestActorRef(new HttpOutcomingSender(dummyActor))
+        val stoppedSender = TestActorRef(new HttpOutcomingSender(dummyActor, HttpReceptionist.DefaultSumoBotChannel))
         system.stop(stoppedSender)
 
         testProbe.expectTerminated(dummyActor)

--- a/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
+++ b/src/test/scala/com/sumologic/sumobot/http_frontend/SumoBotHttpServerTest.scala
@@ -138,6 +138,40 @@ class SumoBotHttpServerTest
 
         disconnectPromise.success(None)
       }
+
+      "sending messages in multiple connections" in {
+        val probeA = TestProbe()
+        val probeB = TestProbe()
+
+        val disconnectPromiseA = sendWebSocketMessages(Array("help", "help"), probeA.ref)
+        val disconnectPromiseB = sendWebSocketMessages(Array("when did you start?", "when did you start?"), probeB.ref)
+
+        eventually {
+          val firstResponseA = probeA.expectMsgClass(classOf[TextMessage.Strict])
+          firstResponseA.getStrictText should include("Help")
+        }
+
+        eventually {
+          val secondResponseA = probeA.expectMsgClass(classOf[TextMessage.Strict])
+          secondResponseA.getStrictText should include("Help")
+        }
+
+        eventually {
+          val firstResponseB = probeB.expectMsgClass(classOf[TextMessage.Strict])
+          firstResponseB.getStrictText should include("I started at ")
+        }
+
+        eventually {
+          val secondResponseB = probeB.expectMsgClass(classOf[TextMessage.Strict])
+          secondResponseB.getStrictText should include("I started at ")
+        }
+
+        probeA.expectNoMessage(100.millis)
+        probeB.expectNoMessage(100.millis)
+
+        disconnectPromiseA.success(None)
+        disconnectPromiseB.success(None)
+      }
     }
 
     "send proper AllowOrigin header" when {


### PR DESCRIPTION
Previously, all connections in sumobot-over-HTTP shared the same user and channel. When multiple people used sumobot-over-HTTP server at the same time, they would see conversations made by other users (specifically bot replies).

With this PR, all connections are now assigned a new user and channel, making it possible for multiple people to use the same sumobot-over-HTTP server, without interference.

##### Limitations
- Authentication information is not taken into account when creating those temporary channels/users.
- `RtmState` in BotPlugin is not updated with new channels and users.