### PR TITLE
Support for multiple Scala versions + gradle releasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased][unreleased]
+## [Unreleased]
+
+## [1.0.3] - 2019-11-13
+
+### Added
+- Multiple Scala Version support: `2.11`, `2.12`
+- Releasing new versions using Gradle
+
+### Changed
+- Updated Gradle configuration as a primary build tool
+- Artifact id has a Scala version suffix
+
+## [0.1]
+
 ### Added
 - Bot framework started.
 - Plugin for Jenkins/Hudson.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,71 @@ After starting Sumo Bot, you can visit started server at `http://localhost:8080/
 
 To run server exposed to external world, change `host` to `0.0.0.0`. For advanced configuration options, see: [`config/sumobot.conf.example`](https://github.com/SumoLogic/sumobot/blob/master/config/sumobot.conf.example).
 
+
+### [Dev] How to build
+
+To build project in default Scala version:
+```
+gradlew build
+```
+
+To build project in any supported Scala version:
+```
+gradlew build -PscalaVersion=2.12.8
+```
+
+### [Dev] Managing Scala versions
+
+This project supports multiple versions of Scala. Supported versions are listed in `gradle.properties`.
+- `supportedScalaVersions` - list of supported versions (Gradle prevents building with versions from 
+outside this list)
+- `defaultScalaVersion` - default version of Scala used for building - can be overridden with `-PscalaVersion`
+
 ### [Dev] How to release new version
+1. Make sure you have all credentials - access to `Open Source` vault in 1Password.
+    1. Can login as `sumoapi` https://oss.sonatype.org/index.html
+    2. Can import and verify the signing key:
+        ```
+        gpg --import ~/Desktop/api.private.key
+        gpg-agent --daemon
+        touch a
+        gpg --use-agent --sign a
+        gpg -k
+        ```
+    3. Have nexus and signing credentials in `~/.gradle/gradle.properties`
+        ```
+        nexus_username=sumoapi
+        nexus_password=${sumoapi_password_for_sonatype_nexus}
+        signing.gnupg.executable=gpg
+        signing.gnupg.keyName=${id_of_imported_sumoapi_key}
+        signing.gnupg.passphrase=${password_for_imported_sumoapi_key}
+        ```
+2. Remove `-SNAPSHOT` suffix from `version` in `build.gradle`
+3. Make a release branch with Scala version and project version, ex. `sumobot-1.0.3`: 
+    ```
+    export RELEASE_VERSION=sumobot-1.0.3
+    git checkout -b ${RELEASE_VERSION}
+    git add build.gradle
+    git commit -m "[release] ${RELEASE_VERSION}"
+    ```
+4. Perform a release in selected Scala versions:
+    ```
+    gradlew build publish -PscalaVersion=2.11.12
+    gradlew build publish -PscalaVersion=2.12.8
+    ```
+5. Go to https://oss.sonatype.org/index.html#stagingRepositories, search for com.sumologic and release your repo. 
+NOTE: If you had to login, reload the URL. It doesn't take you to the right page post-login
+6. Update the `README.md` and `CHANGELOG.md` with the new version and set upcoming snapshot `version` 
+in `build.gradle`, ex. `1.0.4-SNAPSHOT` 
+7. Commit the change and push as a PR:
+    ```
+    git add build.gradle README.md CHANGELOG.md
+    git commit -m "[release] Updating version after release ${RELEASE_VERSION}"
+    git push origin master:${RELEASE_VERSION}
+    ```
+
+
+### [Dev] ~~Deprecated (Maven) version releasing~~
 1. Make sure you have all credentials.
   * Can login as `sumoapi` https://oss.sonatype.org/index.html
   * Have nexus credentials ~/.m2/settings.xml

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        maven {
+            url "https://dl.bintray.com/ngbinh/maven"
+        }
     }
     dependencies {
         classpath "org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_$scalaMajorVersion:1.0.1"
@@ -34,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    compile "com.github.slack-scala-client:slack-scala-client_2.11:0.2.7"
+    compile "com.github.slack-scala-client:slack-scala-client_${scalaMajorVersion}:0.2.7"
     compile "com.typesafe.akka:akka-testkit_${scalaMajorVersion}:${akkaVersion}"
     compile "com.typesafe.akka:akka-stream_${scalaMajorVersion}:${akkaVersion}"
     compile "org.scalatest:scalatest_${scalaMajorVersion}:3.0.8"
@@ -46,7 +49,7 @@ dependencies {
     compile("org.apache.httpcomponents:httpclient:4.3.6") {
         force = true
     }
-    compile "org.scalatra.scalate:scalate-core_2.11:1.9.4"
+    compile "org.scalatra.scalate:scalate-core_${scalaMajorVersion}:1.9.4"
     compile "org.slf4j:slf4j-log4j12:1.7.12"
     compile "com.amazonaws:aws-java-sdk-support:${awsSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-s3:${awsSdkVersion}"
@@ -66,9 +69,9 @@ dependencies {
     compile "org.dom4j:dom4j:2.1.1"
     compile "com.google.guava:guava:27.1-jre"
     compile "commons-beanutils:commons-beanutils:1.9.3"
-    compile "com.typesafe.play:play-json_2.11:2.7.1"
-    compile "com.pauldijou:jwt-play-json_2.11:3.1.0"
-    compile "com.typesafe.akka:akka-http_2.11:10.1.10"
+    compile "com.typesafe.play:play-json_${scalaMajorVersion}:2.7.1"
+    compile "com.pauldijou:jwt-play-json_${scalaMajorVersion}:3.1.0"
+    compile "com.typesafe.akka:akka-http_${scalaMajorVersion}:10.1.10"
     compile "org.joda:joda-convert:1.9.2"
     compile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.0.31-beta"
@@ -98,7 +101,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             groupId(project.group)
-            artifactId(project.name)
+            artifactId(project.name + "_$scalaMajorVersion")
             version(project.version)
 
             pom {

--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ dependencies {
     compile("net.liftweb:lift-json_${scalaMajorVersion}:3.3.0") {
         exclude group: "org.specs2", module: "specs2_${scalaMajorVersion}"
     }
-    compile "org.scala-lang:scala-compiler:2.11.12"
-    compile "org.scala-lang:scalap:2.11.12"
-    compile "org.scala-lang:scala-reflect:2.11.12"
+    compile "org.scala-lang:scala-compiler:${scalaMajorVersion}.${scalaMinorVersion}"
+    compile "org.scala-lang:scalap:${scalaMajorVersion}.${scalaMinorVersion}"
+    compile "org.scala-lang:scala-reflect:${scalaMajorVersion}.${scalaMinorVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:2.10.0"
     compile "com.fasterxml.jackson.core:jackson-annotations:2.10.0"
     compile "com.fasterxml.jackson.core:jackson-core:2.10.0"

--- a/build.gradle
+++ b/build.gradle
@@ -94,15 +94,17 @@ application {
 
 ext.gitCommitIdAbbrev = System.getenv('GIT_COMMIT_ID_ABBREV') ?: 'git rev-parse --verify --short=12 HEAD'.execute().text.trim()
 
-task sourcesJar(type: Jar) {
+task sourcesJar(type: Jar, dependsOn: classes) {
     archiveClassifier.set('sources')
     from(sourceSets.main.allJava) {
         expand(project: [version: project.version], git: [commit: [id: [abbrev: gitCommitIdAbbrev]]])
     }
+    from(sourceSets.main.allScala)
 }
 
-task javadocJar(type: Jar) {
+task javadocJar(type: Jar, dependsOn: scaladoc) {
     from javadoc
+    from scaladoc
     archiveClassifier.set('javadoc')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ apply plugin: "maven-publish"
 apply plugin: "scalaStyle"
 apply plugin: "application"
 apply plugin: "com.github.hierynomus.license"
+apply plugin: "signing"
 
 group = "com.sumologic.sumobot"
 description = "A Slack bot implemented in Akka"
@@ -94,10 +95,15 @@ application {
 ext.gitCommitIdAbbrev = System.getenv('GIT_COMMIT_ID_ABBREV') ?: 'git rev-parse --verify --short=12 HEAD'.execute().text.trim()
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier.set('sources')
     from(sourceSets.main.allJava) {
         expand(project: [version: project.version], git: [commit: [id: [abbrev: gitCommitIdAbbrev]]])
     }
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    archiveClassifier.set('javadoc')
 }
 
 publishing {
@@ -135,8 +141,23 @@ publishing {
 
             from(components.java)
             artifact(sourcesJar)
+            artifact(javadocJar)
         }
     }
+    repositories {
+        maven {
+            url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            credentials {
+                username project.property('nexus_username')
+                password project.property('nexus_password')
+            }
+        }
+    }
+}
+
+signing {
+    useGpgCmd()
+    sign publishing.publications.maven
 }
 
 license {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+def scalaMajorVersion = gradle.ext.scalaMajorVersion
+def scalaMinorVersion = gradle.ext.scalaMinorVersion
+
 buildscript {
     repositories {
         mavenCentral()
@@ -10,7 +13,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_$scalaMajorVersion:1.0.1"
+        classpath "org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_${gradle.ext.scalaMajorVersion}:1.0.1"
         classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"
     }
 }
@@ -101,7 +104,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             groupId(project.group)
-            artifactId(project.name + "_$scalaMajorVersion")
+            artifactId(project.name + "_${scalaMajorVersion}")
             version(project.version)
 
             pom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ javaSourceVersion = 1.8
 javaTargetVersion = 1.8
 
 scalaMajorVersion = 2.11
-scalaVersion = '$scalaMajorVersion.12'
+scalaMinorVersion = 12
 akkaVersion = 2.5.25
 awsSdkVersion = 1.11.669

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.configureondemand=true
 javaSourceVersion = 1.8
 javaTargetVersion = 1.8
 
-scalaMajorVersion = 2.11
-scalaMinorVersion = 12
+supportedScalaVersions = 2.11.12, 2.12.8
+defaultScalaVersion = 2.11.12
 akkaVersion = 2.5.25
 awsSdkVersion = 1.11.669

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.sumologic.sumobot</groupId>
-  <artifactId>sumobot</artifactId>
+  <artifactId>sumobot_${scala.version.major}</artifactId>
   <packaging>jar</packaging>
   <version>1.0.3-SNAPSHOT</version>
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,32 @@
 rootProject.name = 'sumobot'
+determineAndSetScalaVersion()
+
+private void determineAndSetScalaVersion() {
+    def selectedScalaVersion = resolveScalaVersion()
+    applyScalaVersion(selectedScalaVersion)
+    println "Scala version: ${gradle.ext.scalaMajorVersion}.${gradle.ext.scalaMinorVersion}"
+}
+
+private String resolveScalaVersion() {
+    def selectedScalaVersion = ext.has("scalaVersion")
+            ? ext.scalaVersion
+            : ext.defaultScalaVersion
+
+    if (!ext.supportedScalaVersions
+            .split(",")
+            .collect{it.trim()}
+            .contains(selectedScalaVersion)) {
+        throw new GradleException("Unsupported scala version '$selectedScalaVersion'. " +
+                "Available versions: '${ext.supportedScalaVersions}'")
+    }
+
+    return selectedScalaVersion
+}
+
+private void applyScalaVersion(selectedScalaVersion) {
+    def m = (selectedScalaVersion =~ /(\d+\.\d+)\.(\d+(-(RC|M)\d+)?)/)
+    m.matches()
+
+    gradle.ext.scalaMajorVersion = m.group(1)
+    gradle.ext.scalaMinorVersion = m.group(2)
+}


### PR DESCRIPTION
###### Description
This branch: 
1. Contains changes that allow releasing artifacts targeted for specified Scala versions.
2. Migrates to Gradle as a new default build / release tool.

After merging this branch I can publicly release new versions: `sumobot_2.11:1.0.3` and `sumobot_2.12:1.0.3`

###### Details
- updated Gradle configuration for building
- appended Scala suffix to artifact id (ex. `sumobot_2.12`)
- provided a to mechanism manage Scala versions (`defaultScalaVersion`, `supportedScalaVersions`)
- configured Gradle artifact signing and releasing to nexus
- updated `README.md`

###### Testing performed
- [x] Builded project in different Scala versions  
  - `gradlew build`
  - `gradlew build -PscalaVersion=2.11.12`
  - `gradlew build -PscalaVersion=2.12.8`
- [x] Performed a test upload to nexus
  - `gradlew publish`
- [x] Compared gradle vs maven artifacts in local m2
- [x] Compared gradle vs maven artifacts in nexus