### PR TITLE
Employing ben-manes:gradle-versions-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0"
         classpath "org.owasp:dependency-check-gradle:5.2.4"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.38.0"
     }
 }
 
@@ -26,6 +27,7 @@ apply plugin: "application"
 apply plugin: "com.github.hierynomus.license"
 apply plugin: "signing"
 apply plugin: "org.owasp.dependencycheck"
+apply plugin: "com.github.ben-manes.versions"
 
 group = "com.sumologic.sumobot"
 description = "A Slack bot implemented in Akka"


### PR DESCRIPTION
So that one can run:
```
./gradlew dependencyUpdates
Picked up _JAVA_OPTIONS: -Djava.awt.headless=true
Scala version: 2.12.12
Configuration on demand is an incubating feature.

> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.github.ben-manes:gradle-versions-plugin:0.38.0
 - com.github.slack-scala-client:slack-scala-client_2.12:0.2.14
 - com.offbytwo.jenkins:jenkins-client:0.3.8
 - gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.15.0
 - org.quartz-scheduler:quartz:2.3.2
 - org.scalatra.scalate:scalate-core_2.12:1.9.6

The following dependencies have later milestone versions:
 - com.amazonaws:aws-java-sdk-s3 [1.11.761 -> 1.11.988]
     https://aws.amazon.com/sdkforjava
 - com.amazonaws:aws-java-sdk-support [1.11.761 -> 1.11.988]
     https://aws.amazon.com/sdkforjava
 - com.fasterxml.jackson.core:jackson-annotations [2.10.0 -> 2.12.2]
     http://github.com/FasterXML/jackson
 - com.fasterxml.jackson.core:jackson-core [2.10.0 -> 2.12.2]
     https://github.com/FasterXML/jackson-core
 - com.fasterxml.jackson.core:jackson-databind [2.10.0 -> 2.12.2]
     http://github.com/FasterXML/jackson
 - com.google.guava:guava [27.1-jre -> 30.1.1-jre]
     https://github.com/google/guava
 - com.mchange:c3p0 [0.9.5.4 -> 0.9.5.5]
     https://github.com/swaldman/c3p0
 - com.pauldijou:jwt-play-json_2.12 [3.1.0 -> 5.0.0]
     http://pauldijou.fr/jwt-scala/
 - com.typesafe.akka:akka-http_2.12 [10.1.14 -> 10.2.4]
     https://akka.io
 - com.typesafe.akka:akka-stream_2.12 [2.5.32 -> 2.6.13]
     https://akka.io/
 - com.typesafe.akka:akka-testkit_2.12 [2.5.32 -> 2.6.13]
     https://akka.io/
 - com.typesafe.play:play-json_2.12 [2.7.4 -> 2.10.0-RC2]
     https://github.com/playframework/play-json
 - commons-beanutils:commons-beanutils [1.9.4 -> 20030211.134440]
 - junit:junit [4.12 -> 4.13.2]
     http://junit.org
 - net.liftweb:lift-json_2.12 [3.4.1 -> 3.4.3]
     http://www.liftweb.net
 - org.apache.httpcomponents:httpclient [4.3.6 -> 4.5.13]
     http://hc.apache.org/httpcomponents-client
 - org.dom4j:dom4j [2.1.1 -> 2.1.3]
     http://dom4j.github.io/
 - org.joda:joda-convert [1.9.2 -> 2.2.1]
     https://www.joda.org/${joda.artifactId}/
 - org.mockito:mockito-core [2.0.31-beta -> 3.8.0]
     https://github.com/mockito/mockito
 - org.owasp:dependency-check-gradle [5.2.4 -> 6.1.4]
     https://github.com/jeremylong/dependency-check-gradle
 - org.scala-lang:scala-compiler [2.12.12 -> 2.13.5]
     https://www.scala-lang.org/
 - org.scala-lang:scala-reflect [2.12.12 -> 2.13.5]
     https://www.scala-lang.org/
 - org.scala-lang:scalap [2.12.12 -> 2.13.5]
     https://www.scala-lang.org/
 - org.scalatest:scalatest_2.12 [3.0.8 -> 3.3.0-SNAP3]
     http://www.scalatest.org
 - org.slf4j:slf4j-log4j12 [1.7.12 -> 2.0.0-alpha1]
     http://www.slf4j.org

Gradle release-candidate updates:
 - Gradle: [6.8 -> 6.8.3 -> 7.0-rc-1]
```