### PR TITLE
resolve() added

### DIFF
--- a/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Bootstrap.scala
@@ -42,7 +42,7 @@ object Bootstrap {
     def readConfig: Config
   }
   case object FileConfigReader extends ConfigReader {
-    override def readConfig: Config = ConfigFactory.parseFile(new File(configFileLocation))
+    override def readConfig: Config = ConfigFactory.parseFile(new File(configFileLocation)).resolve()
   }
   case object ClasspathConfigReader extends ConfigReader {
     override def readConfig: Config = ConfigFactory.load(configFileLocation)


### PR DESCRIPTION
**What**: now people can use `${SYNTAX}` in the `config/sumobot.conf` to refer to variables - e.g. system environment variables.

**Why**: I need it for my company's k8s framework as it requires all credentials to be passed via environment variables

We are using lightbend/config here, but not the full solution, but a partial method of `parseFile`. The default lightbend/config does the resolution by itself.

**Testing performed**: I ran the modified sumobot with a config having the variables and the values were resolved. Without it, the error message was:
```
Exception in thread "main" com.typesafe.config.ConfigException$NotResolved: need to Config#resolve() each config before using it, see the API docs for Config#resolve()
        at com.typesafe.config.impl.SimpleConfig.checkValid(SimpleConfig.java:1103)
        at akka.actor.ActorSystem$Settings.<init>(ActorSystem.scala:322)
        at akka.actor.ActorSystemImpl.<init>(ActorSystem.scala:704)
        at akka.actor.ActorSystem$.apply(ActorSystem.scala:258)
        at akka.actor.ActorSystem$.apply(ActorSystem.scala:302)
        at akka.actor.ActorSystem$.apply(ActorSystem.scala:276)
        at com.sumologic.sumobot.core.Bootstrap$.bootstrap(Bootstrap.scala:56)
        at com.sumologic.sumobot.core.Bootstrap$.bootstrap(Bootstrap.scala:68)
        at com.sumologic.sumobot.Main$.delayedEndpoint$com$sumologic$sumobot$Main$1(Main.scala:35)
        at com.sumologic.sumobot.Main$delayedInit$body.apply(Main.scala:28)
        at scala.Function0.apply$mcV$sp(Function0.scala:39)
        at scala.Function0.apply$mcV$sp$(Function0.scala:39)
        at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
        at scala.App.$anonfun$main$1$adapted(App.scala:80)
        at scala.collection.immutable.List.foreach(List.scala:431)
        at scala.App.main(App.scala:80)
        at scala.App.main$(App.scala:78)
        at com.sumologic.sumobot.Main$.main(Main.scala:28)
        at com.sumologic.sumobot.Main.main(Main.scala)
```