### PR TITLE
Fixing empty sender NullPointerException

### DIFF
--- a/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
@@ -115,7 +115,7 @@ class Receptionist(rtmClient: SlackRtmClient,
       asyncClient.openIm(userId)
       pendingIMSessionsByUserId = pendingIMSessionsByUserId + (userId -> (doneRecipient, doneMessage))
 
-    case message: Message if !tooOld(message.ts, message) =>
+    case message: Message if !tooOld(message.ts, message) && message.user.isDefined =>
       translateAndDispatch(message.channel, message.user.get, message.text, message.ts, threadTimestamp = message.thread_ts,
         message.attachments.getOrElse(Seq()), fromBot = message.bot_id.isDefined)
 


### PR DESCRIPTION
Fixing the following error message:
```
[ERROR] [08/17/2021 02:02:56.382] [sumobot-akka.actor.default-dispatcher-17] [akka://sumobot/user/receptionist] None.get
java.util.NoSuchElementException: None.get
        at scala.None$.get(Option.scala:627)
        at scala.None$.get(Option.scala:626)
        at com.sumologic.sumobot.core.Receptionist$$anonfun$receive$1.applyOrElse(Receptionist.scala:119)
```

It's likely this shows up when a sumobot sees a message by another sumobot (or itself).

The bug has been introduced in https://github.com/SumoLogic/sumobot/pull/86/files#diff-66b6346dd597c15e00911a366c3ea76e9dc6d893eb2bed8e891bb8b1f611a36bR119