### PR TITLE
Support for attachment titles

### DIFF
--- a/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/Receptionist.scala
@@ -165,7 +165,9 @@ class Receptionist(rtmClient: SlackRtmClient,
     } else {
       BotSender(userId)
     }
-    val msgToBot = translateMessage(channelId, idTimestamp, threadTimestamp, text, attachments.map(a => IncomingMessageAttachment(a.text.getOrElse(""))), sentBy)
+    val msgToBot = translateMessage(channelId, idTimestamp, threadTimestamp, text,
+      attachments.map(a => IncomingMessageAttachment(a.text.getOrElse(""), a.title.getOrElse(""))),
+      sentBy)
     if (userId != selfId) {
       log.info(s"Dispatching message: $msgToBot")
       context.system.eventStream.publish(msgToBot)

--- a/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
+++ b/src/main/scala/com/sumologic/sumobot/core/model/Messages.scala
@@ -70,7 +70,7 @@ case class IncomingMessage(canonicalText: String,
                            attachments: Seq[IncomingMessageAttachment] = Seq(),
                            sentBy: Sender)
 
-case class IncomingMessageAttachment(text: String)
+case class IncomingMessageAttachment(text: String, title: String)
 
 case class OutgoingImage(channel: Channel, image: File, contentType: String, title: String,
                          comment: Option[String] = None, threadTimestamp: Option[String] = None)


### PR DESCRIPTION
**Why**: the newest incarnation of the Pagerduty -> Slack migration seems to send the human readable text in `title`, not in `text`.

**What**: adding the `title` field to the `IncomingMessageAttachment`