### PR TITLE
Declaring some dependencies as exported

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     ext.comFasterxmlJacksonVersion = '2.13.4'
 }
 
-apply plugin: "java"
+apply plugin: "java-library"
 apply plugin: "scala"
 apply plugin: "maven-publish"
 apply plugin: "application"
@@ -38,16 +38,16 @@ description = "A Slack bot implemented in Akka"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-version = '2.0.1'
+version = '2.0.2-SNAPSHOT'
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation "com.github.slack-scala-client:slack-scala-client_${scalaMajorVersion}:0.4.0"
-    implementation "com.typesafe.akka:akka-testkit_${scalaMajorVersion}:${akkaVersion}"
-    implementation "com.typesafe.akka:akka-stream_${scalaMajorVersion}:${akkaVersion}"
+    api "com.github.slack-scala-client:slack-scala-client_${scalaMajorVersion}:0.4.0"
+    api "com.typesafe.akka:akka-testkit_${scalaMajorVersion}:${akkaVersion}"
+    api "com.typesafe.akka:akka-stream_${scalaMajorVersion}:${akkaVersion}"
     implementation "org.scalatest:scalatest_${scalaMajorVersion}:3.0.8"
     implementation("com.offbytwo.jenkins:jenkins-client:0.3.8") {
         exclude group: 'commons-beanutils', module: 'commons-beanutils'
@@ -78,9 +78,9 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-core:${comFasterxmlJacksonVersion}"
     implementation "org.dom4j:dom4j:2.1.3"
     implementation "commons-beanutils:commons-beanutils:1.9.3"
-    implementation "com.typesafe.play:play-json_${scalaMajorVersion}:2.9.2"
-    implementation "com.pauldijou:jwt-play-json_${scalaMajorVersion}:3.1.0"
-    implementation "com.typesafe.akka:akka-http_${scalaMajorVersion}:10.2.9"
+    api "com.typesafe.play:play-json_${scalaMajorVersion}:2.9.2"
+    api "com.pauldijou:jwt-play-json_${scalaMajorVersion}:3.1.0"
+    api "com.typesafe.akka:akka-http_${scalaMajorVersion}:10.2.9"
     implementation "org.joda:joda-convert:2.2.2"
     implementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:4.8.0"


### PR DESCRIPTION
Otherwise we would make users of the library declare them themselves, which is suboptimal.

The problem was likely introduced in #296 